### PR TITLE
fix(http): decode compressed response bodies before matching

### DIFF
--- a/protocols/http/request.go
+++ b/protocols/http/request.go
@@ -10,7 +10,6 @@ import (
 	"github.com/chainreactors/neutron/operators"
 	"github.com/chainreactors/neutron/protocols"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
@@ -488,10 +487,11 @@ func (r *Request) responseToDSLMap(req *http.Request, resp *http.Response, host,
 	}
 	data["header"] = headerBuilder.String()
 
-	body, _ := ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	body, _ := readResponseBody(resp)
 	data["body"] = string(body)
-	if resp.ContentLength > -1 {
+	if strings.TrimSpace(resp.Header.Get("Content-Encoding")) != "" {
+		data["content_length"] = len(body)
+	} else if resp.ContentLength > -1 {
 		data["content_length"] = resp.ContentLength
 	} else {
 		data["content_length"] = len(body)

--- a/protocols/http/response_decode.go
+++ b/protocols/http/response_decode.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+func readResponseBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, nil
+	}
+
+	rawBody, err := ioutil.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	decodedBody, err := decodeResponseBody(rawBody, resp.Header.Get("Content-Encoding"))
+	if err != nil {
+		// Fall back to the raw body so malformed encoding headers do not abort matching.
+		return rawBody, nil
+	}
+
+	return decodedBody, nil
+}
+
+func decodeResponseBody(body []byte, contentEncoding string) ([]byte, error) {
+	encodings, ok := supportedEncodings(contentEncoding)
+	if !ok || len(encodings) == 0 {
+		return body, nil
+	}
+
+	decoded := body
+	var err error
+	for i := len(encodings) - 1; i >= 0; i-- {
+		decoded, err = decodeBodyWithEncoding(decoded, encodings[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return decoded, nil
+}
+
+func supportedEncodings(contentEncoding string) ([]string, bool) {
+	if strings.TrimSpace(contentEncoding) == "" {
+		return nil, true
+	}
+
+	parts := strings.Split(contentEncoding, ",")
+	encodings := make([]string, 0, len(parts))
+	for _, part := range parts {
+		encoding := strings.ToLower(strings.TrimSpace(part))
+		switch encoding {
+		case "", "identity":
+			continue
+		case "gzip", "x-gzip", "deflate":
+			encodings = append(encodings, encoding)
+		default:
+			return nil, false
+		}
+	}
+
+	return encodings, true
+}
+
+func decodeBodyWithEncoding(body []byte, encoding string) ([]byte, error) {
+	var (
+		reader io.ReadCloser
+		err    error
+	)
+
+	switch encoding {
+	case "gzip", "x-gzip":
+		reader, err = gzip.NewReader(bytes.NewReader(body))
+	case "deflate":
+		reader, err = zlib.NewReader(bytes.NewReader(body))
+	default:
+		return body, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	return ioutil.ReadAll(reader)
+}

--- a/protocols/http/response_decode_test.go
+++ b/protocols/http/response_decode_test.go
@@ -1,0 +1,95 @@
+package http
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseToDSLMapDecodesGzipBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		Header: http.Header{
+			"Content-Encoding": []string{"gzip"},
+			"Content-Type":     []string{"text/plain"},
+		},
+		Body: io.NopCloser(bytes.NewReader(gzipBody(t, "vulnexists"))),
+	}
+
+	data := (&Request{}).responseToDSLMap(req, resp, "https://example.com", "https://example.com", time.Second, nil)
+	require.Equal(t, "vulnexists", data["body"])
+	require.Equal(t, len("vulnexists"), data["content_length"])
+}
+
+func TestResponseToDSLMapDecodesDeflateBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		Header: http.Header{
+			"Content-Encoding": []string{"deflate"},
+			"Content-Type":     []string{"text/plain"},
+		},
+		Body: io.NopCloser(bytes.NewReader(deflateBody(t, "vulnexists"))),
+	}
+
+	data := (&Request{}).responseToDSLMap(req, resp, "https://example.com", "https://example.com", time.Second, nil)
+	require.Equal(t, "vulnexists", data["body"])
+	require.Equal(t, len("vulnexists"), data["content_length"])
+}
+
+func TestResponseToDSLMapFallsBackWhenGzipHeaderIsInvalid(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		Header: http.Header{
+			"Content-Encoding": []string{"gzip"},
+			"Content-Type":     []string{"text/plain"},
+		},
+		Body: io.NopCloser(bytes.NewReader([]byte("plain-body"))),
+	}
+
+	data := (&Request{}).responseToDSLMap(req, resp, "https://example.com", "https://example.com", time.Second, nil)
+	require.Equal(t, "plain-body", data["body"])
+	require.Equal(t, len("plain-body"), data["content_length"])
+}
+
+func gzipBody(t *testing.T, body string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return buf.Bytes()
+}
+
+func deflateBody(t *testing.T, body string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := zlib.NewWriter(&buf)
+	_, err := writer.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary
- decode `gzip` and `deflate` HTTP response bodies before neutron matchers/extractors read them
- keep matcher behavior stable when servers send invalid `gzip` headers by falling back to the raw body
- add protocol HTTP tests covering gzip, deflate, and invalid-gzip fallback cases

## Testing
- `go test ./protocols/http`
