### PR TITLE
增强 xray 兼容性与修复运行时变量求值

### DIFF
--- a/common/dsl/codegen.go
+++ b/common/dsl/codegen.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 type Emitter interface {
@@ -145,12 +146,36 @@ func generateGrouped(child *Node, parentOp string, e Emitter, r *Result) string 
 }
 
 func genComparison(node *Node, e Emitter, r *Result) string {
-	left := node.Children[0]
+	left := unwrapFieldNode(node.Children[0])
 	right := node.Children[1]
 
-	if left.Type == NodeVariable && left.Value.(string) == "status_code" {
+	if isStatusCodeVariable(left) {
 		if code, ok := toInt(right); ok {
-			return e.StatusCode(code)
+			clause := e.StatusCode(code)
+			switch node.Op {
+			case "==":
+				return clause
+			case "!=":
+				return e.Not(clause)
+			default:
+				r.Warnings = append(r.Warnings, fmt.Sprintf("status_code operator %s approximated as equals", node.Op))
+				return clause
+			}
+		}
+	}
+
+	if part, ok := variableName(left); ok {
+		if needle, headerOK := headerVariableNeedle(part, resolveValue(right)); headerOK {
+			clause := e.Contains(e.Field("all_headers"), needle)
+			switch node.Op {
+			case "==":
+				return clause
+			case "!=":
+				return e.Not(clause)
+			default:
+				r.Warnings = append(r.Warnings, fmt.Sprintf("header variable operator %s approximated as contains", node.Op))
+				return clause
+			}
 		}
 	}
 
@@ -195,8 +220,9 @@ func genContains(node *Node, e Emitter, r *Result) string {
 		r.Errors = append(r.Errors, fmt.Sprintf("contains requires at least 2 args, got %d", len(node.Children)))
 		return ""
 	}
-	if node.Children[0].Type == NodeVariable {
-		part := NormalizePart(node.Children[0].Value.(string))
+	fieldNode := unwrapFieldNode(node.Children[0])
+	if fieldNode.Type == NodeVariable {
+		part := NormalizePart(fieldNode.Value.(string))
 		if part == "favicon_hash" || part == "body_favicon_hash" {
 			q, err := e.FaviconHash(resolveValue(node.Children[1]))
 			if err != nil {
@@ -205,8 +231,11 @@ func genContains(node *Node, e Emitter, r *Result) string {
 			}
 			return q
 		}
+		if needle, ok := headerVariableNeedle(part, resolveValue(node.Children[1])); ok {
+			return e.Contains(e.Field("all_headers"), needle)
+		}
 	}
-	field := resolveField(node.Children[0], e)
+	field := resolveField(fieldNode, e)
 	value := resolveValue(node.Children[1])
 	return e.Contains(field, value)
 }
@@ -216,10 +245,18 @@ func genContainsMulti(node *Node, e Emitter, r *Result, isAll bool) string {
 		r.Errors = append(r.Errors, fmt.Sprintf("%s requires at least 2 args", node.FuncName))
 		return ""
 	}
-	field := resolveField(node.Children[0], e)
+	fieldNode := unwrapFieldNode(node.Children[0])
+	field := resolveField(fieldNode, e)
 	clauses := make([]string, 0, len(node.Children)-1)
 	for _, arg := range node.Children[1:] {
-		clauses = append(clauses, e.Contains(field, resolveValue(arg)))
+		value := resolveValue(arg)
+		if part, ok := variableName(fieldNode); ok {
+			if needle, headerOK := headerVariableNeedle(part, value); headerOK {
+				clauses = append(clauses, e.Contains(e.Field("all_headers"), needle))
+				continue
+			}
+		}
+		clauses = append(clauses, e.Contains(field, value))
 	}
 	if isAll {
 		return e.Group(e.And(clauses...))
@@ -242,12 +279,61 @@ func genFaviconHash(node *Node, e Emitter, r *Result) string {
 }
 
 func resolveField(node *Node, e Emitter) string {
+	node = unwrapFieldNode(node)
 	if node.Type == NodeVariable {
 		if part, ok := node.Value.(string); ok {
 			return e.Field(NormalizePart(part))
 		}
 	}
 	return fmt.Sprintf("%v", node.Value)
+}
+
+var transparentFieldFuncs = map[string]bool{
+	"to_lower":   true,
+	"to_number":  true,
+	"to_string":  true,
+	"to_upper":   true,
+	"trim_space": true,
+}
+
+var headerVariableParts = map[string]bool{
+	"location":         true,
+	"set_cookie":       true,
+	"www_authenticate": true,
+}
+
+func unwrapFieldNode(node *Node) *Node {
+	for node != nil && node.Type == NodeCall && transparentFieldFuncs[node.FuncName] && len(node.Children) == 1 {
+		node = node.Children[0]
+	}
+	return node
+}
+
+func variableName(node *Node) (string, bool) {
+	if node == nil || node.Type != NodeVariable {
+		return "", false
+	}
+	part, ok := node.Value.(string)
+	if !ok {
+		return "", false
+	}
+	return NormalizePart(part), true
+}
+
+func isStatusCodeVariable(node *Node) bool {
+	part, ok := variableName(node)
+	return ok && part == "status_code"
+}
+
+func headerVariableNeedle(part, value string) (string, bool) {
+	part = NormalizePart(part)
+	if !headerVariableParts[part] {
+		return "", false
+	}
+	if value == "" {
+		return part + ":", true
+	}
+	return part + ": " + value, true
 }
 
 func resolveValue(node *Node) string {
@@ -271,12 +357,40 @@ func toInt(node *Node) (int, bool) {
 }
 
 func NormalizePart(part string) string {
+	part = strings.TrimSpace(part)
 	switch part {
-	case "":
+	case "", "body", "body_string":
 		return "body"
-	case "header":
+	case "header", "headers", "all_headers", "raw_header":
 		return "all_headers"
+	case "status", "status_code":
+		return "status_code"
 	default:
-		return part
+		if base, ok := stripRequestIndex(part); ok {
+			switch base {
+			case "", "body", "body_string":
+				return "body"
+			case "header", "headers", "all_headers", "raw_header":
+				return "all_headers"
+			case "status", "status_code":
+				return "status_code"
+			default:
+				if headerVariableParts[base] {
+					return base
+				}
+			}
+		}
 	}
+	return part
+}
+
+func stripRequestIndex(part string) (string, bool) {
+	idx := strings.LastIndex(part, "_")
+	if idx <= 0 || idx == len(part)-1 {
+		return "", false
+	}
+	if _, err := strconv.Atoi(part[idx+1:]); err != nil {
+		return "", false
+	}
+	return part[:idx], true
 }

--- a/common/dsl/codegen.go
+++ b/common/dsl/codegen.go
@@ -165,7 +165,8 @@ func genComparison(node *Node, e Emitter, r *Result) string {
 	}
 
 	if part, ok := variableName(left); ok {
-		if needle, headerOK := headerVariableNeedle(part, resolveValue(right)); headerOK {
+		if isHeaderVariable(part, e) {
+			needle := headerNeedle(part, resolveValue(right))
 			clause := e.Contains(e.Field("all_headers"), needle)
 			switch node.Op {
 			case "==":
@@ -231,7 +232,8 @@ func genContains(node *Node, e Emitter, r *Result) string {
 			}
 			return q
 		}
-		if needle, ok := headerVariableNeedle(part, resolveValue(node.Children[1])); ok {
+		if isHeaderVariable(part, e) {
+			needle := headerNeedle(part, resolveValue(node.Children[1]))
 			return e.Contains(e.Field("all_headers"), needle)
 		}
 	}
@@ -251,8 +253,8 @@ func genContainsMulti(node *Node, e Emitter, r *Result, isAll bool) string {
 	for _, arg := range node.Children[1:] {
 		value := resolveValue(arg)
 		if part, ok := variableName(fieldNode); ok {
-			if needle, headerOK := headerVariableNeedle(part, value); headerOK {
-				clauses = append(clauses, e.Contains(e.Field("all_headers"), needle))
+			if isHeaderVariable(part, e) {
+				clauses = append(clauses, e.Contains(e.Field("all_headers"), headerNeedle(part, value)))
 				continue
 			}
 		}
@@ -288,25 +290,22 @@ func resolveField(node *Node, e Emitter) string {
 	return fmt.Sprintf("%v", node.Value)
 }
 
-var transparentFieldFuncs = map[string]bool{
-	"to_lower":   true,
-	"to_number":  true,
-	"to_string":  true,
-	"to_upper":   true,
-	"trim_space": true,
-}
-
-var headerVariableParts = map[string]bool{
-	"location":         true,
-	"set_cookie":       true,
-	"www_authenticate": true,
-}
-
 func unwrapFieldNode(node *Node) *Node {
-	for node != nil && node.Type == NodeCall && transparentFieldFuncs[node.FuncName] && len(node.Children) == 1 {
+	for node != nil && node.Type == NodeCall && IsFieldTransparent(node.FuncName) && len(node.Children) == 1 {
 		node = node.Children[0]
 	}
 	return node
+}
+
+// isHeaderVariable returns true if the emitter treats part as a generic header
+// field (i.e. it has no dedicated platform mapping and falls through to the
+// same target as "all_headers"). This replaces a hardcoded allowlist with the
+// emitter's own knowledge of its field mappings.
+func isHeaderVariable(part string, e Emitter) bool {
+	if part == "" || part == "all_headers" || part == "header" || part == "body" || part == "status_code" {
+		return false
+	}
+	return e.Field(part) == e.Field("all_headers")
 }
 
 func variableName(node *Node) (string, bool) {
@@ -325,15 +324,11 @@ func isStatusCodeVariable(node *Node) bool {
 	return ok && part == "status_code"
 }
 
-func headerVariableNeedle(part, value string) (string, bool) {
-	part = NormalizePart(part)
-	if !headerVariableParts[part] {
-		return "", false
-	}
+func headerNeedle(part, value string) string {
 	if value == "" {
-		return part + ":", true
+		return part + ":"
 	}
-	return part + ": " + value, true
+	return part + ": " + value
 }
 
 func resolveValue(node *Node) string {
@@ -375,9 +370,7 @@ func NormalizePart(part string) string {
 			case "status", "status_code":
 				return "status_code"
 			default:
-				if headerVariableParts[base] {
-					return base
-				}
+				return base
 			}
 		}
 	}

--- a/common/dsl/codegen_test.go
+++ b/common/dsl/codegen_test.go
@@ -220,6 +220,138 @@ func TestGenerateNewFields(t *testing.T) {
 	}
 }
 
+func TestGenerateHeaderVariablesUseAllHeadersNeedles(t *testing.T) {
+	tests := []struct {
+		expr   string
+		fofa   string
+		hunter string
+		censys string
+	}{
+		{
+			`contains(location, "/login")`,
+			`header="location: /login"`,
+			`header="location: /login"`,
+			`services.http.response.headers: "location: /login"`,
+		},
+		{
+			`contains(set_cookie, "JSESSIONID")`,
+			`header="set_cookie: JSESSIONID"`,
+			`header="set_cookie: JSESSIONID"`,
+			`services.http.response.headers: "set_cookie: JSESSIONID"`,
+		},
+		{
+			`contains(www_authenticate, "Basic")`,
+			`header="www_authenticate: Basic"`,
+			`header="www_authenticate: Basic"`,
+			`services.http.response.headers: "www_authenticate: Basic"`,
+		},
+		{
+			`location == "/admin"`,
+			`header="location: /admin"`,
+			`header="location: /admin"`,
+			`services.http.response.headers: "location: /admin"`,
+		},
+		{
+			`contains_all(location, "/one", "/two")`,
+			`(header="location: /one" && header="location: /two")`,
+			`(header="location: /one" && header="location: /two")`,
+			`(services.http.response.headers: "location: /one" AND services.http.response.headers: "location: /two")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			node, err := Parse(tt.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := map[string]string{"fofa": tt.fofa, "hunter": tt.hunter, "censys": tt.censys}
+			for platform, want := range expected {
+				e, _ := GetEmitter(platform)
+				r := Generate(node, e)
+				if r.Query != want {
+					t.Errorf("[%s] got %q, want %q", platform, r.Query, want)
+				}
+				if r.HasErrors() {
+					t.Errorf("[%s] unexpected errors: %v", platform, r.Errors)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateStatusCodeStringAndWrappedComparisons(t *testing.T) {
+	tests := []struct {
+		expr string
+		want string
+	}{
+		{`status_code == "200"`, `status_code="200"`},
+		{`to_number(status_code) == "401"`, `status_code="401"`},
+		{`status_code != "404"`, `!(status_code="404")`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			node, err := Parse(tt.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := Generate(node, &FOFAEmitter{})
+			if r.Query != tt.want {
+				t.Errorf("got %q, want %q", r.Query, tt.want)
+			}
+			if r.HasErrors() {
+				t.Errorf("unexpected errors: %v", r.Errors)
+			}
+		})
+	}
+}
+
+func TestGenerateHistoryVariablesNormalizeForQueries(t *testing.T) {
+	tests := []struct {
+		expr   string
+		fofa   string
+		censys string
+	}{
+		{
+			`contains(body_0, "redirect")`,
+			`body="redirect"`,
+			`services.http.response.body: "redirect"`,
+		},
+		{
+			`contains(headers_0, "location: /login")`,
+			`header="location: /login"`,
+			`services.http.response.headers: "location: /login"`,
+		},
+		{
+			`status_0 == "302"`,
+			`status_code="302"`,
+			`services.http.response.status_code: 302`,
+		},
+		{
+			`contains(location_1, "/login") && status_code_1 != "404"`,
+			`header="location: /login" && !(status_code="404")`,
+			`services.http.response.headers: "location: /login" AND NOT services.http.response.status_code: 404`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			node, err := Parse(tt.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := Generate(node, &FOFAEmitter{}).Query; got != tt.fofa {
+				t.Errorf("[fofa] got %q, want %q", got, tt.fofa)
+			}
+			if got := Generate(node, &CensysEmitter{}).Query; got != tt.censys {
+				t.Errorf("[censys] got %q, want %q", got, tt.censys)
+			}
+		})
+	}
+}
+
 func TestEndToEndAllEngines(t *testing.T) {
 	expr := `contains(body, "wp-content") && contains(body, "wp-includes")`
 	expected := map[string]string{

--- a/common/dsl/codegen_test.go
+++ b/common/dsl/codegen_test.go
@@ -352,6 +352,73 @@ func TestGenerateHistoryVariablesNormalizeForQueries(t *testing.T) {
 	}
 }
 
+func TestIsFieldTransparentRegisteredCorrectly(t *testing.T) {
+	transparent := []string{"to_lower", "to_upper", "to_number", "to_string", "trim_space"}
+	for _, name := range transparent {
+		if !IsFieldTransparent(name) {
+			t.Errorf("%s should be field-transparent", name)
+		}
+	}
+	notTransparent := []string{"md5", "base64", "len", "concat", "reverse", "hex_encode"}
+	for _, name := range notTransparent {
+		if IsFieldTransparent(name) {
+			t.Errorf("%s should NOT be field-transparent", name)
+		}
+	}
+}
+
+func TestIsHeaderVariableUsesEmitterFieldMapping(t *testing.T) {
+	tests := []struct {
+		part     string
+		platform string
+		want     bool
+	}{
+		{"location", "fofa", true},
+		{"set_cookie", "fofa", true},
+		{"www_authenticate", "fofa", true},
+		{"x_powered_by", "fofa", true},
+		{"content_type", "fofa", true},
+		{"body", "fofa", false},
+		{"all_headers", "fofa", false},
+		{"status_code", "fofa", false},
+		{"server", "fofa", false},
+		{"title", "fofa", false},
+		// censys has a dedicated content_type field
+		{"content_type", "censys", false},
+		{"location", "censys", true},
+	}
+	for _, tt := range tests {
+		e, _ := GetEmitter(tt.platform)
+		got := isHeaderVariable(tt.part, e)
+		if got != tt.want {
+			t.Errorf("isHeaderVariable(%q, %s) = %v, want %v", tt.part, tt.platform, got, tt.want)
+		}
+	}
+}
+
+func TestGenerateUnmappedHeaderVariablesProduceNeedleQueries(t *testing.T) {
+	tests := []struct {
+		expr string
+		fofa string
+	}{
+		{`contains(content_type, "json")`, `header="content_type: json"`},
+		{`contains(x_powered_by, "PHP")`, `header="x_powered_by: PHP"`},
+		{`x_forwarded_for == "127.0.0.1"`, `header="x_forwarded_for: 127.0.0.1"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			node, err := Parse(tt.expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := Generate(node, &FOFAEmitter{})
+			if r.Query != tt.fofa {
+				t.Errorf("got %q, want %q", r.Query, tt.fofa)
+			}
+		})
+	}
+}
+
 func TestEndToEndAllEngines(t *testing.T) {
 	expr := `contains(body, "wp-content") && contains(body, "wp-includes")`
 	expected := map[string]string{

--- a/common/dsl/dsl.go
+++ b/common/dsl/dsl.go
@@ -694,7 +694,11 @@ func registerDefaultFunctions() {
 				return nil, ErrInvalidDslFunction
 			}
 
-			length = int(args[0].(float64))
+			var err error
+			length, err = dslLength(args[0])
+			if err != nil {
+				return nil, err
+			}
 
 			if argSize == 2 {
 				inputCharSet := toString(args[1])
@@ -716,7 +720,11 @@ func registerDefaultFunctions() {
 				return nil, ErrInvalidDslFunction
 			}
 
-			length = int(args[0].(float64))
+			var err error
+			length, err = dslLength(args[0])
+			if err != nil {
+				return nil, err
+			}
 
 			if argSize == 2 {
 				badChars = toString(args[1])
@@ -736,7 +744,11 @@ func registerDefaultFunctions() {
 				return nil, ErrInvalidDslFunction
 			}
 
-			length = int(args[0].(float64))
+			var err error
+			length, err = dslLength(args[0])
+			if err != nil {
+				return nil, err
+			}
 
 			if argSize == 2 {
 				badChars = toString(args[1])
@@ -753,7 +765,10 @@ func registerDefaultFunctions() {
 				return nil, ErrInvalidDslFunction
 			}
 
-			length := int(args[0].(float64))
+			length, err := dslLength(args[0])
+			if err != nil {
+				return nil, err
+			}
 			badNumbers := ""
 
 			if argSize == 2 {
@@ -1460,6 +1475,17 @@ func xrayNumber(value interface{}) (float64, bool) {
 		n, err := strconv.ParseFloat(strings.TrimSpace(toString(value)), 64)
 		return n, err == nil
 	}
+}
+
+func dslLength(value interface{}) (int, error) {
+	n, ok := xrayNumber(value)
+	if !ok {
+		return 0, ErrParsingArg
+	}
+	if n < 0 {
+		return 0, ErrParsingArg
+	}
+	return int(n), nil
 }
 
 func xrayCompare(left, right interface{}, op string) bool {

--- a/common/dsl/dsl.go
+++ b/common/dsl/dsl.go
@@ -86,6 +86,18 @@ func refreshDefaultFunctions() {
 	FunctionNames = GetFunctionNames(DefaultHelperFunctions)
 }
 
+// IsFieldTransparent returns true if the named DSL function does not change
+// the identity of the response part it wraps (e.g. to_lower(body) is still body).
+func IsFieldTransparent(name string) bool {
+	ensureDefaultFunctions()
+	for _, f := range functions {
+		if f.Name == name {
+			return f.IsFieldTransparent
+		}
+	}
+	return false
+}
+
 func addFunction(function dslFunction) error {
 	for _, f := range functions {
 		if function.Name == f.Name {
@@ -162,10 +174,10 @@ func registerDefaultFunctions() {
 
 	MustAddFunction(NewWithPositionalArgs("to_upper", 1, false, func(args ...interface{}) (interface{}, error) {
 		return strings.ToUpper(toString(args[0])), nil
-	}))
+	}).WithFieldTransparent())
 	MustAddFunction(NewWithPositionalArgs("to_lower", 1, false, func(args ...interface{}) (interface{}, error) {
 		return strings.ToLower(toString(args[0])), nil
-	}))
+	}).WithFieldTransparent())
 	MustAddFunction(NewWithMultipleSignatures("sort", []string{
 		"(input string) string",
 		"(input number) string",
@@ -251,7 +263,7 @@ func registerDefaultFunctions() {
 	}))
 	MustAddFunction(NewWithPositionalArgs("trim_space", 1, false, func(args ...interface{}) (interface{}, error) {
 		return strings.TrimSpace(toString(args[0])), nil
-	}))
+	}).WithFieldTransparent())
 	MustAddFunction(NewWithPositionalArgs("trim_prefix", 2, false, func(args ...interface{}) (interface{}, error) {
 		return strings.TrimPrefix(toString(args[0]), toString(args[1])), nil
 	}))
@@ -1080,10 +1092,10 @@ func registerDefaultFunctions() {
 			return float64(sint), nil
 		}
 		return nil, fmt.Errorf("%v could not be converted to int", argStr)
-	}))
+	}).WithFieldTransparent())
 	MustAddFunction(NewWithPositionalArgs("to_string", 1, false, func(args ...interface{}) (interface{}, error) {
 		return toString(args[0]), nil
-	}))
+	}).WithFieldTransparent())
 	MustAddFunction(NewWithPositionalArgs("dec_to_hex", 1, false, func(args ...interface{}) (interface{}, error) {
 		if number, ok := args[0].(float64); ok {
 			hexNum := strconv.FormatInt(int64(number), 16)

--- a/common/dsl/dsl_test.go
+++ b/common/dsl/dsl_test.go
@@ -306,12 +306,12 @@ func TestDateTimeDslExpressions(t *testing.T) {
 
 func TestRandDslExpressions(t *testing.T) {
 	randDslExpressions := map[string]string{
-		`rand_base(10, "")`:         `[a-zA-Z0-9]{10}`,
-		`rand_base(5, "abc")`:       `[abc]{5}`,
-		`rand_base(5)`:              `[a-zA-Z0-9]{5}`,
-		`rand_char("abc")`:          `[abc]{1}`,
-		`rand_char("")`:             `[a-zA-Z0-9]{1}`,
-		`rand_char()`:               `[a-zA-Z0-9]{1}`,
+		`rand_base(10, "")`:                  `[a-zA-Z0-9]{10}`,
+		`rand_base(5, "abc")`:                `[abc]{5}`,
+		`rand_base(5)`:                       `[a-zA-Z0-9]{5}`,
+		`rand_char("abc")`:                   `[abc]{1}`,
+		`rand_char("")`:                      `[a-zA-Z0-9]{1}`,
+		`rand_char()`:                        `[a-zA-Z0-9]{1}`,
 		`rand_text_alpha(10, "abc")`:         `[^abc]{10}`,
 		`rand_text_alpha(10, "")`:            `[a-zA-Z]{10}`,
 		`rand_text_alpha(10)`:                `[a-zA-Z]{10}`,

--- a/common/dsl/func.go
+++ b/common/dsl/func.go
@@ -15,6 +15,11 @@ type dslFunction struct {
 	NumberOfArgs       int
 	Signatures         []string
 	ExpressionFunction govaluate.ExpressionFunction
+	// IsFieldTransparent marks functions that do not change the identity of
+	// the response part they wrap (e.g. to_lower, to_upper). The codegen
+	// layer uses this to "see through" wrapping calls and identify the
+	// underlying field variable.
+	IsFieldTransparent bool
 }
 
 func (d dslFunction) GetSignatures() []string {
@@ -65,6 +70,11 @@ func (d dslFunction) Exec(args ...interface{}) (interface{}, error) {
 	//}
 
 	return result, err
+}
+
+func (d dslFunction) WithFieldTransparent() dslFunction {
+	d.IsFieldTransparent = true
+	return d
 }
 
 func (d dslFunction) hash(args ...interface{}) string {

--- a/common/dsl/lexer.go
+++ b/common/dsl/lexer.go
@@ -117,20 +117,61 @@ func Lex(input string) ([]Token, error) {
 func lexString(runes []rune, start int) (string, int, error) {
 	quote := runes[start]
 	i := start + 1
-	var buf []rune
+	var buf []byte
 	for i < len(runes) {
 		if runes[i] == '\\' && i+1 < len(runes) {
-			buf = append(buf, runes[i+1])
-			i += 2
+			next := runes[i+1]
+			switch next {
+			case 'x':
+				if i+3 < len(runes) {
+					hi := hexDigitVal(runes[i+2])
+					lo := hexDigitVal(runes[i+3])
+					if hi >= 0 && lo >= 0 {
+						buf = append(buf, byte(hi<<4|lo))
+						i += 4
+						continue
+					}
+				}
+				buf = append(buf, byte(next))
+				i += 2
+			case 'n':
+				buf = append(buf, '\n')
+				i += 2
+			case 'r':
+				buf = append(buf, '\r')
+				i += 2
+			case 't':
+				buf = append(buf, '\t')
+				i += 2
+			case '0':
+				buf = append(buf, 0)
+				i += 2
+			default:
+				buf = append(buf, byte(next))
+				i += 2
+			}
 			continue
 		}
 		if runes[i] == quote {
 			return string(buf), i + 1, nil
 		}
-		buf = append(buf, runes[i])
+		buf = append(buf, []byte(string(runes[i]))...)
 		i++
 	}
 	return "", 0, fmt.Errorf("unterminated string at position %d", start)
+}
+
+func hexDigitVal(r rune) int {
+	switch {
+	case r >= '0' && r <= '9':
+		return int(r - '0')
+	case r >= 'a' && r <= 'f':
+		return int(r-'a') + 10
+	case r >= 'A' && r <= 'F':
+		return int(r-'A') + 10
+	default:
+		return -1
+	}
 }
 
 func lexNumber(runes []rune, start int) (string, int) {

--- a/common/dsl/lexer_test.go
+++ b/common/dsl/lexer_test.go
@@ -95,3 +95,44 @@ func TestLexNot(t *testing.T) {
 		t.Errorf("expected TNot, got %d", tokens[0].Type)
 	}
 }
+
+func TestLexHexEscape(t *testing.T) {
+	tokens, err := Lex(`starts_with(body, "\x1f\x8b")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// tokens: starts_with ( body , "\x1f\x8b" ) EOF
+	strTok := tokens[4]
+	if strTok.Type != TString {
+		t.Fatalf("expected TString, got %d", strTok.Type)
+	}
+	if len(strTok.Value) != 2 {
+		t.Fatalf("expected 2 bytes, got %d bytes: %q", len(strTok.Value), strTok.Value)
+	}
+	if strTok.Value[0] != 0x1f || strTok.Value[1] != 0x8b {
+		t.Errorf("expected \\x1f\\x8b, got %x", []byte(strTok.Value))
+	}
+}
+
+func TestLexStandardEscapes(t *testing.T) {
+	tokens, err := Lex(`"\n\r\t\0"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := tokens[0].Value
+	if s != "\n\r\t\x00" {
+		t.Errorf("expected \\n\\r\\t\\0, got %q", s)
+	}
+}
+
+func TestLexHexMixedWithText(t *testing.T) {
+	tokens, err := Lex(`"PK\x03\x04"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := tokens[0].Value
+	expected := "PK\x03\x04"
+	if s != expected {
+		t.Errorf("expected %q, got %q", expected, s)
+	}
+}

--- a/convert/converter.go
+++ b/convert/converter.go
@@ -444,7 +444,7 @@ func buildReqConditionBlocks(poc *XrayPOC, groups []*requestGroup, topExpr *TopE
 	for i, g := range groups {
 		req := map[string]interface{}{
 			"method": g.method,
-			"path":   []string{"{{BaseURL}}" + g.path},
+			"path":   []string{xrayTemplatePath(g.path)},
 		}
 		if len(g.headers) > 0 {
 			req["headers"] = g.headers
@@ -588,6 +588,18 @@ func rewriteTemplatePlaceholders(value string, aliases map[string]string) string
 		}
 		return match
 	})
+}
+
+// xrayTemplatePath returns the full path expression for a converted xray template.
+// xray POC paths are always absolute (relative to host root), so we use RootURL
+// instead of BaseURL. This avoids doubled path segments when the scan target
+// includes a path (e.g. http://host/app/) — BaseURL would include /app/ and the
+// template path /app/login would produce /app/app/login.
+func xrayTemplatePath(path string) string {
+	if strings.HasPrefix(path, "/") {
+		return "{{RootURL}}" + path
+	}
+	return "{{BaseURL}}" + path
 }
 
 func normalizeRequestPath(path string, ctx *conversionContext) string {
@@ -1374,15 +1386,7 @@ func regexGroupIndex(pattern, groupName string) int {
 
 // appendGeneratedQueries loads the YAML as a neutron Template, calls ToQuery()
 // to generate fofa-query/hunter-query from matchers, and writes them back.
-func appendGeneratedQueries(yamlData []byte, tmpl map[string]interface{}) (out []byte) {
-	out = yamlData
-	defer func() {
-		if recover() != nil {
-			// Query generation is best-effort during xray conversion. Keep the
-			// converted template instead of aborting the whole batch.
-			out = yamlData
-		}
-	}()
+func appendGeneratedQueries(yamlData []byte, tmpl map[string]interface{}) []byte {
 	var t templates.Template
 	if yaml.Unmarshal(yamlData, &t) != nil {
 		return yamlData
@@ -1459,7 +1463,7 @@ func convertGroup(method, path string, headers map[string]string, body string, r
 
 	req := map[string]interface{}{
 		"method": method,
-		"path":   []string{"{{BaseURL}}" + path},
+		"path":   []string{xrayTemplatePath(path)},
 	}
 	if len(headers) > 0 {
 		req["headers"] = headers

--- a/convert/converter.go
+++ b/convert/converter.go
@@ -99,7 +99,7 @@ func ConvertPOC(poc *XrayPOC) ([]byte, error) {
 			"name":     poc.Detail.Fingerprint.Name,
 			"author":   "xray-converter",
 			"severity": "info",
-			"tags":     "neutron,converted",
+			"tags":     "neutron,xray,converted",
 		},
 	}
 
@@ -159,18 +159,31 @@ type requestGroup struct {
 type conversionContext struct {
 	variables     map[string]interface{}
 	variableOrder []string
+	variableAlias map[string]string
 	payloads      map[string][]string
 	runtimeVars   map[string]bool
 }
 
 func newConversionContext(poc *XrayPOC) *conversionContext {
-	variables, order := convertSetVariables(poc.Set)
+	aliases := variableAliases(collectVariableNames(poc))
+	variables, order := convertSetVariables(poc.Set, aliases)
 	return &conversionContext{
 		variables:     variables,
 		variableOrder: order,
-		payloads:      flattenPayloads(poc.Payloads),
+		variableAlias: aliases,
+		payloads:      flattenPayloads(poc.Payloads, aliases),
 		runtimeVars:   map[string]bool{},
 	}
+}
+
+func (ctx *conversionContext) aliasName(name string) string {
+	if ctx == nil || len(ctx.variableAlias) == 0 {
+		return name
+	}
+	if alias, ok := ctx.variableAlias[name]; ok {
+		return alias
+	}
+	return name
 }
 
 func (ctx *conversionContext) noSuffixVariables() map[string]bool {
@@ -277,12 +290,16 @@ func groupRules(poc *XrayPOC, keys []string, ctx *conversionContext, preserveRul
 
 	for _, ruleName := range keys {
 		rule := poc.Rules[ruleName]
-		expr := strings.TrimSpace(rule.Expression)
-		if expr == "" {
+		rawExpr := strings.TrimSpace(rule.Expression)
+		if rawExpr == "" {
 			continue
 		}
+		expr := rawExpr
+		if len(ctx.variableAlias) > 0 {
+			expr = translateXrayExpression(rawExpr, ctx.variableAlias)
+		}
 		ruleExprs[ruleName] = expr
-		if !hasXrayRequest(rule, expr) {
+		if !hasXrayRequest(rule, rawExpr) {
 			continue
 		}
 		method := rule.Request.Method
@@ -293,15 +310,18 @@ func groupRules(poc *XrayPOC, keys []string, ctx *conversionContext, preserveRul
 		if path == "" {
 			path = "/"
 		}
+		path = rewriteTemplatePlaceholders(path, ctx.variableAlias)
 		path = normalizeRequestPath(path, ctx)
+		headers := rewriteHeaderPlaceholders(rule.Request.Headers, ctx.variableAlias)
+		body := rewriteTemplatePlaceholders(rule.Request.Body, ctx.variableAlias)
 
-		key := method + ":" + path + ":" + headersKey(rule.Request.Headers) + ":" + rule.Request.Body
+		key := method + ":" + path + ":" + headersKey(headers) + ":" + body
 		if preserveRuleOrder {
 			key = key + ":" + ruleName
 		}
 		ruleGroup[ruleName] = key
 		extractors := outputExtractors(rule.Output, ctx)
-		payloads := payloadsForRequest(path, rule.Request.Headers, rule.Request.Body, ctx.payloads)
+		payloads := payloadsForRequest(path, headers, body, ctx.payloads)
 
 		if idx, ok := groupIndex[key]; ok {
 			groups[idx].rules = append(groups[idx].rules, ruleName)
@@ -316,8 +336,8 @@ func groupRules(poc *XrayPOC, keys []string, ctx *conversionContext, preserveRul
 			groups = append(groups, &requestGroup{
 				method:     method,
 				path:       path,
-				headers:    rule.Request.Headers,
-				body:       rule.Request.Body,
+				headers:    headers,
+				body:       body,
 				redirects:  rule.Request.FollowRedirects,
 				rules:      []string{ruleName},
 				exprs:      []string{expr},
@@ -543,6 +563,33 @@ func collectPlaceholders(s string, out map[string]bool) {
 	}
 }
 
+func rewriteHeaderPlaceholders(headers map[string]string, aliases map[string]string) map[string]string {
+	if len(headers) == 0 || len(aliases) == 0 {
+		return headers
+	}
+	rewritten := make(map[string]string, len(headers))
+	for key, value := range headers {
+		rewritten[rewriteTemplatePlaceholders(key, aliases)] = rewriteTemplatePlaceholders(value, aliases)
+	}
+	return rewritten
+}
+
+func rewriteTemplatePlaceholders(value string, aliases map[string]string) string {
+	if value == "" || len(aliases) == 0 || !strings.Contains(value, "{{") {
+		return value
+	}
+	return placeholderRE.ReplaceAllStringFunc(value, func(match string) string {
+		parts := placeholderRE.FindStringSubmatch(match)
+		if len(parts) < 2 {
+			return match
+		}
+		if alias, ok := aliases[parts[1]]; ok {
+			return "{{" + alias + "}}"
+		}
+		return match
+	})
+}
+
 func normalizeRequestPath(path string, ctx *conversionContext) string {
 	path = strings.TrimSpace(strings.TrimPrefix(path, "^"))
 	path = strings.ReplaceAll(path, " ", "%20")
@@ -570,7 +617,7 @@ func slashSafeRuntimePlaceholder(name string) string {
 	return fmt.Sprintf(`/{{trim_prefix(%s, "/")}}`, name)
 }
 
-func flattenPayloads(root XrayPayloadRoot) map[string][]string {
+func flattenPayloads(root XrayPayloadRoot, aliases map[string]string) map[string][]string {
 	if len(root.Payloads) == 0 {
 		return nil
 	}
@@ -589,7 +636,8 @@ func flattenPayloads(root XrayPayloadRoot) map[string][]string {
 		}
 		sort.Strings(varKeys)
 		for _, varName := range varKeys {
-			result[varName] = append(result[varName], normalizeXrayScalar(fmt.Sprint(row[varName])))
+			outName := aliasVariableName(varName, aliases)
+			result[outName] = append(result[outName], normalizeXrayScalar(fmt.Sprint(row[varName])))
 		}
 	}
 	return result
@@ -647,7 +695,7 @@ func scalarYAMLNode(value interface{}) *yaml.Node {
 	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: fmt.Sprint(value)}
 }
 
-func convertSetVariables(set map[string]interface{}) (map[string]interface{}, []string) {
+func convertSetVariables(set map[string]interface{}, aliases map[string]string) (map[string]interface{}, []string) {
 	if len(set) == 0 {
 		return nil, nil
 	}
@@ -664,7 +712,8 @@ func convertSetVariables(set map[string]interface{}) (map[string]interface{}, []
 		if key == "RootURL" && isRootURLSetExpression(value) {
 			continue
 		}
-		vars[key] = translateXraySetExpression(value)
+		outKey := aliasVariableName(key, aliases)
+		vars[outKey] = translateXraySetExpression(value, aliases)
 	}
 	if _, ok := vars["randomstr"]; ok {
 		if _, exists := vars["randstr"]; !exists {
@@ -692,20 +741,135 @@ func isRootURLSetExpression(expr string) bool {
 	}
 }
 
-func translateXraySetExpression(expr string) string {
+var neutronBuiltinVariableNames = map[string]bool{
+	"BaseURL":  true,
+	"RootURL":  true,
+	"Hostname": true,
+	"Host":     true,
+	"Port":     true,
+	"Path":     true,
+	"File":     true,
+	"Scheme":   true,
+}
+
+var neutronRuntimeVariableNames = map[string]bool{
+	"all_headers":       true,
+	"body":              true,
+	"body_favicon_hash": true,
+	"content_type":      true,
+	"duration":          true,
+	"favicon_content":   true,
+	"favicon_hash":      true,
+	"header":            true,
+	"latency":           true,
+	"matched":           true,
+	"raw":               true,
+	"status_code":       true,
+	"title":             true,
+}
+
+func collectVariableNames(poc *XrayPOC) map[string]bool {
+	names := map[string]bool{}
+	if poc == nil {
+		return names
+	}
+	for key, raw := range poc.Set {
+		value := strings.TrimSpace(fmt.Sprint(raw))
+		if key == "RootURL" && isRootURLSetExpression(value) {
+			continue
+		}
+		names[key] = true
+	}
+	for _, rule := range poc.Rules {
+		for key := range rule.Output {
+			names[key] = true
+		}
+	}
+	for _, row := range poc.Payloads.Payloads {
+		for key := range row {
+			names[key] = true
+		}
+	}
+	return names
+}
+
+func variableAliases(names map[string]bool) map[string]string {
+	if len(names) == 0 {
+		return nil
+	}
+	used := map[string]bool{}
+	for key := range names {
+		used[key] = true
+	}
+	aliases := map[string]string{}
+	for key := range names {
+		if !isReservedVariableName(key) {
+			continue
+		}
+		alias := "xray_" + key
+		for i := 2; used[alias]; i++ {
+			alias = fmt.Sprintf("xray_%s_%d", key, i)
+		}
+		aliases[key] = alias
+		used[alias] = true
+	}
+	if len(aliases) == 0 {
+		return nil
+	}
+	return aliases
+}
+
+func isReservedVariableName(name string) bool {
+	if neutronBuiltinVariableNames[name] || neutronRuntimeVariableNames[name] {
+		return true
+	}
+	switch name {
+	case "true", "false", "nil":
+		return true
+	}
+	for _, fn := range dsl.FunctionNames {
+		if name == fn {
+			return true
+		}
+	}
+	return false
+}
+
+func aliasVariableName(name string, aliases map[string]string) string {
+	if len(aliases) == 0 {
+		return name
+	}
+	if alias, ok := aliases[name]; ok {
+		return alias
+	}
+	return name
+}
+
+func translateXrayExpression(expr string, aliases map[string]string) string {
+	if len(aliases) == 0 {
+		return expr
+	}
+	ast, err := ParseToASTWithAliases(expr, aliases)
+	if err != nil {
+		return rewriteTemplatePlaceholders(expr, aliases)
+	}
+	return ast.String()
+}
+
+func translateXraySetExpression(expr string, aliases map[string]string) string {
 	trimmed := strings.TrimSpace(expr)
 	if strings.EqualFold(trimmed, "get404Path()") {
 		return "{{rand_text_alphanumeric(16)}}"
 	}
 	if strings.Contains(trimmed, "{{") {
-		return normalizeXrayScalar(trimmed)
+		return rewriteTemplatePlaceholders(normalizeXrayScalar(trimmed), aliases)
 	}
 	if base, ok := parseBFormat16Expression(trimmed); ok {
-		return "{{hex_encode(" + base + ")}}"
+		return "{{hex_encode(" + aliasVariableName(base, aliases) + ")}}"
 	}
-	if ast, err := ParseToAST(trimmed); err == nil {
+	if ast, err := ParseToASTWithAliases(trimmed, aliases); err == nil {
 		if ast.Type == dsl.NodeLiteral {
-			return normalizeXrayScalar(trimmed)
+			return literalSetValue(ast.Value)
 		}
 		if ast.Type == dsl.NodeVariable && !strings.HasPrefix(trimmed, "request.") {
 			if ast.String() != trimmed {
@@ -725,6 +889,15 @@ func translateXraySetExpression(expr string) string {
 		return "{{" + translated + "}}"
 	}
 	return normalizeXrayScalar(trimmed)
+}
+
+func literalSetValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 func parseBFormat16Expression(expr string) (string, bool) {
@@ -819,9 +992,10 @@ func outputExtractors(output map[string]interface{}, ctx *conversionContext) []i
 		if name == "" || expr == "" {
 			continue
 		}
+		outName := ctx.aliasName(name)
 
-		if spec, tempName, dslExpr, ok := resolveOutputTransform(expr, name, sources); ok {
-			ctx.runtimeVars[name] = true
+		if spec, tempName, dslExpr, ok := resolveOutputTransform(expr, outName, sources); ok {
+			ctx.runtimeVars[outName] = true
 			ctx.runtimeVars[tempName] = true
 			group := regexGroupIndex(spec.Pattern, spec.GroupName)
 			if group == 0 {
@@ -844,12 +1018,12 @@ func outputExtractors(output map[string]interface{}, ctx *conversionContext) []i
 				extractors = append(extractors, extractor)
 			}
 
-			dslKey := name + "\x00dsl\x00" + dslExpr
+			dslKey := outName + "\x00dsl\x00" + dslExpr
 			if !seen[dslKey] {
 				seen[dslKey] = true
 				extractors = append(extractors, map[string]interface{}{
 					"type":     "dsl",
-					"name":     name,
+					"name":     outName,
 					"dsl":      []string{dslExpr},
 					"internal": true,
 				})
@@ -862,12 +1036,12 @@ func outputExtractors(output map[string]interface{}, ctx *conversionContext) []i
 			if spec.GroupName == "" {
 				spec.GroupName = name
 			}
-			ctx.runtimeVars[name] = true
+			ctx.runtimeVars[outName] = true
 			group := regexGroupIndex(spec.Pattern, spec.GroupName)
 			if group == 0 {
 				group = 1
 			}
-			key := name + "\x00" + spec.Part + "\x00" + spec.Pattern + "\x00" + strconv.Itoa(group)
+			key := outName + "\x00" + spec.Part + "\x00" + spec.Pattern + "\x00" + strconv.Itoa(group)
 			if seen[key] {
 				continue
 			}
@@ -875,7 +1049,7 @@ func outputExtractors(output map[string]interface{}, ctx *conversionContext) []i
 
 			extractor := map[string]interface{}{
 				"type":     "regex",
-				"name":     name,
+				"name":     outName,
 				"regex":    []string{spec.Pattern},
 				"group":    group,
 				"internal": true,
@@ -889,8 +1063,8 @@ func outputExtractors(output map[string]interface{}, ctx *conversionContext) []i
 				if ctx.variables == nil {
 					ctx.variables = map[string]interface{}{}
 				}
-				if _, exists := ctx.variables[name]; !exists {
-					ctx.variables[name] = normalizeXrayScalar(fallback)
+				if _, exists := ctx.variables[outName]; !exists {
+					ctx.variables[outName] = normalizeXrayScalar(fallback)
 				}
 			}
 			continue
@@ -1004,17 +1178,18 @@ func outputDSLExtractor(name, expr string, ctx *conversionContext) map[string]in
 	if name == "" || expr == "" || strings.Contains(expr, "submatch") || strings.Contains(expr, "?") {
 		return nil
 	}
-	ast, err := ParseToAST(expr)
+	ast, err := ParseToASTWithAliases(expr, ctx.variableAlias)
 	if err != nil {
 		return nil
 	}
 	if ast.Type == dsl.NodeLiteral {
 		return nil
 	}
-	ctx.runtimeVars[name] = true
+	outName := ctx.aliasName(name)
+	ctx.runtimeVars[outName] = true
 	return map[string]interface{}{
 		"type":     "dsl",
-		"name":     name,
+		"name":     outName,
 		"dsl":      []string{ast.String()},
 		"internal": true,
 	}
@@ -1199,7 +1374,15 @@ func regexGroupIndex(pattern, groupName string) int {
 
 // appendGeneratedQueries loads the YAML as a neutron Template, calls ToQuery()
 // to generate fofa-query/hunter-query from matchers, and writes them back.
-func appendGeneratedQueries(yamlData []byte, tmpl map[string]interface{}) []byte {
+func appendGeneratedQueries(yamlData []byte, tmpl map[string]interface{}) (out []byte) {
+	out = yamlData
+	defer func() {
+		if recover() != nil {
+			// Query generation is best-effort during xray conversion. Keep the
+			// converted template instead of aborting the whole batch.
+			out = yamlData
+		}
+	}()
 	var t templates.Template
 	if yaml.Unmarshal(yamlData, &t) != nil {
 		return yamlData

--- a/convert/converter_test.go
+++ b/convert/converter_test.go
@@ -269,7 +269,7 @@ expression: payload_rule() || set_rule()
 	if !strings.Contains(s, "payloads:") || !strings.Contains(s, "value:") || !strings.Contains(s, "admin/login") {
 		t.Fatalf("missing converted payload values:\n%s", s)
 	}
-	if !strings.Contains(s, "{{BaseURL}}/{{value}}") {
+	if !strings.Contains(s, "{{RootURL}}/{{value}}") {
 		t.Fatalf("payload placeholder path was not preserved:\n%s", s)
 	}
 }
@@ -449,7 +449,7 @@ expression: discover() && fetch_js()
 		"extractors:",
 		"name: js_path",
 		"internal: true",
-		`{{BaseURL}}/{{trim_prefix(js_path, "/")}}`,
+		`{{RootURL}}/{{trim_prefix(js_path, "/")}}`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("missing %q in converted output:\n%s", want, s)
@@ -489,7 +489,7 @@ expression: upload() && fetch()
 		"name: path_raw",
 		"name: path",
 		`replace(path_raw, "\\", "")`,
-		`{{BaseURL}}/{{trim_prefix(path, "/")}}`,
+		`{{RootURL}}/{{trim_prefix(path, "/")}}`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("missing %q in converted output:\n%s", want, s)
@@ -529,7 +529,7 @@ expression: discover() && follow()
 
 	for _, want := range []string{
 		`location="(?P<nextpath>[\/\w]+)`,
-		`{{BaseURL}}/{{trim_prefix(nextpath, "/")}}`,
+		`{{RootURL}}/{{trim_prefix(nextpath, "/")}}`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("missing %q in converted output:\n%s", want, s)

--- a/convert/converter_test.go
+++ b/convert/converter_test.go
@@ -22,6 +22,8 @@ func TestParseToAST(t *testing.T) {
 		{"reverse_matches", `"pattern".matches(response.body_string)`, `regex("pattern", body)`},
 		{"favicon", `faviconHash(response.getIconContent()) == -297069493`, `contains(favicon_hash, "-297069493")`},
 		{"favicon_response_icon", `faviconHash(response.icon()) == 1677186191`, `contains(favicon_hash, "1677186191")`},
+		{"mmh3_get_icon_content", `mmh3(response.getIconContent()) == 1677186191`, `contains(favicon_hash, "1677186191")`},
+		{"mmh3_response_icon", `mmh3(response.icon()) == 1677186191`, `contains(favicon_hash, "1677186191")`},
 		{"mmh3_icon", `mmh3(icon(response)) in [51234238, -1216867457]`, `(contains(favicon_hash, "51234238") || contains(favicon_hash, "-1216867457"))`},
 		{"title_to_title", `response.title_string.contains("Login")`, `contains(title, "Login")`},
 		{"string_title_contains", `string(response.title).contains("Sindoh")`, `contains(title, "Sindoh")`},
@@ -43,6 +45,15 @@ func TestParseToAST(t *testing.T) {
 		{"replace_all", `replaceAll(tmp, "\\", "/")`, `replace(tmp, "\\", "/")`},
 		{"randomstr_alias", `response.body.contains("x" + randomstr)`, `contains(body, concat("x", randstr))`},
 		{"sha_alias", `sha(str1, "sha1") + "=" + sha(str2, "sha1")`, `concat(concat(xray_sha(str1, "sha1"), "="), xray_sha(str2, "sha1"))`},
+		// \xNN hex escape sequences
+		{"hex_escape_0c", `response.body.bcontains(b"\x0c")`, "contains(body, \"\\f\")"},
+		{"hex_escape_gzip", `response.body.bstartsWith(b"\x1F\x8B")`, "starts_with(body, \"\\x1f\\u008b\")"},
+		{"hex_escape_zip", `response.body.bstartsWith(b"PK\x03\x04")`, "starts_with(body, \"PK\\x03\\x04\")"},
+		{"hex_escape_null", `response.body.bcontains(b"SQLite format 3\x00")`, "contains(body, \"SQLite format 3\\x00\")"},
+		// triple-quoted raw strings
+		{"triple_quote_regex", `r'''(?i)<input\b.+?type=["']?file['"]?'''.bmatches(response.body)`, "regex(\"(?i)<input\\\\b.+?type=[\\\"\\']?file[\\'\\\"]?\", body)"},
+		// variable-indexed header access
+		{"header_var_access", `response.headers[rHeader].startsWith(r1)`, `contains(all_headers, r1)`},
 	}
 
 	for _, tt := range tests {
@@ -109,6 +120,15 @@ func TestExprToMatchers(t *testing.T) {
 		},
 		{
 			"favicon_hash", `faviconHash(response.getIconContent()) == -297069493`, 1, "or",
+			func(t *testing.T, r *ConvertResult) {
+				m := r.Matchers[0]
+				if m.Type != "favicon" || m.Part != "favicon_hash" || m.Hash[0] != "-297069493" {
+					t.Errorf("got %+v", m)
+				}
+			},
+		},
+		{
+			"mmh3_favicon_content", `mmh3(response.getIconContent()) == -297069493`, 1, "or",
 			func(t *testing.T, r *ConvertResult) {
 				m := r.Matchers[0]
 				if m.Type != "favicon" || m.Part != "favicon_hash" || m.Hash[0] != "-297069493" {

--- a/convert/e2e_test.go
+++ b/convert/e2e_test.go
@@ -172,6 +172,117 @@ expression: kw()
 	}
 }
 
+func TestEndToEnd_HeaderVariablesGenerateKeyedQueries(t *testing.T) {
+	xrayYAML := `
+name: fingerprint-test--header-query
+detail:
+  fingerprint:
+    name: Header Query
+transport: http
+rules:
+  redirect:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      response.headers["Location"].contains("/login")
+      && response.headers["Set-Cookie"].contains("JSESSIONID")
+      && response.headers["WWW-Authenticate"].contains("Basic")
+expression: redirect()
+`
+	out, err := Convert([]byte(xrayYAML))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	t.Logf("converted:\n%s", out)
+
+	var tmpl templates.Template
+	if err := yaml.Unmarshal(out, &tmpl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tmpl.Compile(nil)
+	for _, req := range tmpl.GetRequests() {
+		(&req.Operators).Compile()
+		req.CompiledOperators = &req.Operators
+	}
+
+	fofa := tmpl.ToQuery().ToFOFA()
+	for _, want := range []string{
+		`header="location: /login"`,
+		`header="set_cookie: JSESSIONID"`,
+		`header="www_authenticate: Basic"`,
+	} {
+		if !strings.Contains(fofa.Query, want) {
+			t.Fatalf("missing %s in fofa query %q\nconverted:\n%s", want, fofa.Query, out)
+		}
+	}
+}
+
+func TestEndToEnd_MultiRequestHistoryVariablesGenerateQueries(t *testing.T) {
+	xrayYAML := `
+name: fingerprint-test--history-query
+detail:
+  fingerprint:
+    name: History Query
+transport: http
+rules:
+  first:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      response.status == 302
+      && response.body_string.contains("redirect")
+      && response.headers["Location"].contains("/login")
+  second:
+    request:
+      method: GET
+      path: /login
+    expression: response.status == 200 && response.body_string.contains("ok")
+expression: first() && second()
+`
+	out, err := Convert([]byte(xrayYAML))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`status_code_1 == 302`,
+		`contains(body_1, "redirect")`,
+		`contains(location_1, "/login")`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("converted template missing history variable %q:\n%s", want, s)
+		}
+	}
+	for _, bad := range []string{"status_0", "status_code_0", "body_0", "headers_0"} {
+		if strings.Contains(s, bad) {
+			t.Fatalf("converted template should not emit zero-based history variable %q:\n%s", bad, s)
+		}
+	}
+
+	var tmpl templates.Template
+	if err := yaml.Unmarshal(out, &tmpl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tmpl.Compile(nil)
+	for _, req := range tmpl.GetRequests() {
+		(&req.Operators).Compile()
+		req.CompiledOperators = &req.Operators
+	}
+
+	fofa := tmpl.ToQuery().ToFOFA()
+	for _, want := range []string{
+		`status_code="302"`,
+		`body="redirect"`,
+		`header="location: /login"`,
+	} {
+		if !strings.Contains(fofa.Query, want) {
+			t.Fatalf("query missing %s in %q\nconverted:\n%s", want, fofa.Query, s)
+		}
+	}
+}
+
 func TestEndToEnd_NoComment(t *testing.T) {
 	xrayYAML := `
 name: fingerprint-test--nocomment

--- a/convert/e2e_test.go
+++ b/convert/e2e_test.go
@@ -326,3 +326,77 @@ expression: kw()
 		t.Errorf("fofa query should contain status_code from matcher, got: %s", fofa.Query)
 	}
 }
+
+func TestXrayTemplatePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/admin", "{{RootURL}}/admin"},
+		{"/", "{{RootURL}}/"},
+		{"/druid/index.html", "{{RootURL}}/druid/index.html"},
+		{"", "{{BaseURL}}"},
+		{"/{{trim_prefix(path, \"/\")}}", "{{RootURL}}/{{trim_prefix(path, \"/\")}}"},
+	}
+	for _, tt := range tests {
+		got := xrayTemplatePath(tt.path)
+		if got != tt.want {
+			t.Errorf("xrayTemplatePath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestEndToEnd_RootURLPreventsDoubledPath(t *testing.T) {
+	xrayYAML := `
+name: fingerprint-test--rooturl-path
+detail:
+  fingerprint:
+    name: RootURL Path Test
+transport: http
+rules:
+  r0:
+    request:
+      method: GET
+      path: /druid/index.html
+    expression: response.status == 200 && response.body_string.contains("druid")
+expression: r0()
+`
+	out, err := Convert([]byte(xrayYAML))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "{{RootURL}}/druid/index.html") {
+		t.Fatalf("expected RootURL in converted path:\n%s", s)
+	}
+	if strings.Contains(s, "{{BaseURL}}/druid") {
+		t.Fatalf("should not use BaseURL for absolute xray path:\n%s", s)
+	}
+
+	var tmpl templates.Template
+	if err := yaml.Unmarshal(out, &tmpl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tmpl.Compile(nil)
+
+	// Simulate target with path: http://host/druid/
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/druid/index.html" {
+			w.WriteHeader(200)
+			fmt.Fprint(w, "druid dashboard")
+			return
+		}
+		w.WriteHeader(404)
+		fmt.Fprintf(w, "not found: %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	// Pass target WITH path — RootURL strips it, so template hits /druid/index.html not /druid/druid/index.html
+	result, err := tmpl.Execute(server.URL+"/druid/", nil)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result == nil || !result.Matched {
+		t.Fatalf("expected match — RootURL should prevent /druid/druid/ doubling")
+	}
+}

--- a/convert/e2e_test.go
+++ b/convert/e2e_test.go
@@ -106,7 +106,7 @@ expression: discover() && fetch_asset()
 	if err != nil {
 		t.Fatalf("convert: %v", err)
 	}
-	if strings.Contains(string(out), "{{BaseURL}}/{{asset_path}}") {
+	if strings.Contains(string(out), "{{RootURL}}/{{asset_path}}") {
 		t.Fatalf("dynamic path with leading-slash extractor should not keep an extra slash:\n%s", string(out))
 	}
 

--- a/convert/lexer.go
+++ b/convert/lexer.go
@@ -206,6 +206,12 @@ func lexRawString(runes []rune, start int) (string, int, error) {
 
 func lexStringMode(runes []rune, start int, raw bool) (string, int, error) {
 	quote := runes[start]
+
+	// Triple-quoted string: '''...''' or """..."""
+	if start+2 < len(runes) && runes[start+1] == quote && runes[start+2] == quote {
+		return lexTripleQuoteString(runes, start+3, raw, quote)
+	}
+
 	i := start + 1
 	var buf []rune
 
@@ -247,11 +253,34 @@ func lexStringMode(runes []rune, start int, raw bool) (string, int, error) {
 	}
 
 	for j := i; j < end; j++ {
-		if runes[j] == '\\' && j+1 < len(runes) {
+		if runes[j] == '\\' && j+1 < end {
 			if raw {
 				buf = append(buf, runes[j], runes[j+1])
 			} else {
-				buf = append(buf, runes[j+1])
+				next := runes[j+1]
+				switch next {
+				case 'x':
+					if j+3 < end {
+						hi := hexDigitVal(runes[j+2])
+						lo := hexDigitVal(runes[j+3])
+						if hi >= 0 && lo >= 0 {
+							buf = append(buf, rune(hi<<4|lo))
+							j += 3
+							continue
+						}
+					}
+					buf = append(buf, next)
+				case 'n':
+					buf = append(buf, '\n')
+				case 'r':
+					buf = append(buf, '\r')
+				case 't':
+					buf = append(buf, '\t')
+				case '0':
+					buf = append(buf, 0)
+				default:
+					buf = append(buf, next)
+				}
 			}
 			j++
 			continue
@@ -259,6 +288,63 @@ func lexStringMode(runes []rune, start int, raw bool) (string, int, error) {
 		buf = append(buf, runes[j])
 	}
 	return string(buf), end + 1, nil
+}
+
+func hexDigitVal(r rune) int {
+	switch {
+	case r >= '0' && r <= '9':
+		return int(r - '0')
+	case r >= 'a' && r <= 'f':
+		return int(r-'a') + 10
+	case r >= 'A' && r <= 'F':
+		return int(r-'A') + 10
+	default:
+		return -1
+	}
+}
+
+func lexTripleQuoteString(runes []rune, start int, raw bool, quote rune) (string, int, error) {
+	var buf []rune
+	for j := start; j < len(runes); j++ {
+		if runes[j] == quote && j+2 < len(runes) && runes[j+1] == quote && runes[j+2] == quote {
+			return string(buf), j + 3, nil
+		}
+		if runes[j] == '\\' && j+1 < len(runes) && !raw {
+			j++
+			next := runes[j]
+			switch next {
+			case 'x':
+				if j+2 < len(runes) {
+					hi := hexDigitVal(runes[j+1])
+					lo := hexDigitVal(runes[j+2])
+					if hi >= 0 && lo >= 0 {
+						buf = append(buf, rune(hi<<4|lo))
+						j += 2
+						continue
+					}
+				}
+				buf = append(buf, next)
+			case 'n':
+				buf = append(buf, '\n')
+			case 'r':
+				buf = append(buf, '\r')
+			case 't':
+				buf = append(buf, '\t')
+			case '0':
+				buf = append(buf, 0)
+			default:
+				buf = append(buf, next)
+			}
+			continue
+		}
+		if runes[j] == '\\' && j+1 < len(runes) && raw {
+			buf = append(buf, runes[j], runes[j+1])
+			j++
+			continue
+		}
+		buf = append(buf, runes[j])
+	}
+	return "", 0, fmt.Errorf("unterminated triple-quoted string at position %d", start-3)
 }
 
 func isStringBoundary(runes []rune, pos int) bool {

--- a/convert/matcher.go
+++ b/convert/matcher.go
@@ -545,3 +545,20 @@ func regexQuote(s string) string {
 	}
 	return out.String()
 }
+
+func hasNonASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 0x7e || s[i] < 0x20 {
+			return true
+		}
+	}
+	return false
+}
+
+func toHex(s string) string {
+	var out strings.Builder
+	for i := 0; i < len(s); i++ {
+		fmt.Fprintf(&out, "%02x", s[i])
+	}
+	return out.String()
+}

--- a/convert/parser.go
+++ b/convert/parser.go
@@ -14,6 +14,19 @@ func ParseToAST(expr string) (*dsl.Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("lex: %w", err)
 	}
+	return parseTokensToAST(tokens)
+}
+
+func ParseToASTWithAliases(expr string, aliases map[string]string) (*dsl.Node, error) {
+	tokens, err := xrayLex(expr)
+	if err != nil {
+		return nil, fmt.Errorf("lex: %w", err)
+	}
+	rewriteIdentifierTokens(tokens, aliases)
+	return parseTokensToAST(tokens)
+}
+
+func parseTokensToAST(tokens []xToken) (*dsl.Node, error) {
 	p := &parser{tokens: tokens}
 	node, err := p.parseOr()
 	if err != nil {
@@ -23,6 +36,28 @@ func ParseToAST(expr string) (*dsl.Node, error) {
 		return nil, fmt.Errorf("unexpected trailing token: %q at pos %d", p.peek().Val, p.pos)
 	}
 	return node, nil
+}
+
+func rewriteIdentifierTokens(tokens []xToken, aliases map[string]string) {
+	if len(aliases) == 0 {
+		return
+	}
+	for i := range tokens {
+		if tokens[i].Type != xTIdent {
+			continue
+		}
+		alias, ok := aliases[tokens[i].Val]
+		if !ok {
+			continue
+		}
+		if i > 0 && tokens[i-1].Type == xTDot {
+			continue
+		}
+		if i+1 < len(tokens) && (tokens[i+1].Type == xTDot || tokens[i+1].Type == xTLParen) {
+			continue
+		}
+		tokens[i].Val = alias
+	}
 }
 
 type parser struct {
@@ -317,15 +352,26 @@ func (p *parser) parseResponseAccess() (*dsl.Node, error) {
 	case "headers":
 		if p.peek().Type == xTLBracket {
 			p.next() // [
-			if p.peek().Type != xTString {
-				return dsl.Variable("all_headers"), nil
+			tok := p.peek()
+			if tok.Type == xTString {
+				hdrName := p.next().Val
+				if p.peek().Type == xTRBracket {
+					p.next()
+				}
+				varName := headerVarName(hdrName)
+				return p.maybeMethodCall(dsl.Variable(varName))
 			}
-			hdrName := p.next().Val
-			if p.peek().Type == xTRBracket {
-				p.next()
+			if tok.Type == xTIdent {
+				p.next() // consume the variable name
+				if p.peek().Type == xTRBracket {
+					p.next()
+				}
+				// Dynamic header access: response.headers[varName]
+				// Cannot bind a specific header at DSL level; use all_headers.
+				// Force startsWith/endsWith → contains since all_headers is the full block.
+				return p.maybeMethodCallForAllHeaders()
 			}
-			varName := headerVarName(hdrName)
-			return p.maybeMethodCall(dsl.Variable(varName))
+			return dsl.Variable("all_headers"), nil
 		}
 		return dsl.Variable("all_headers"), nil
 
@@ -466,6 +512,37 @@ func isVersionMethod(name string) bool {
 	default:
 		return false
 	}
+}
+
+// maybeMethodCallForAllHeaders parses a method call on all_headers,
+// downgrading startsWith/endsWith to contains since all_headers is the
+// full header block (startsWith on the whole block is meaningless).
+func (p *parser) maybeMethodCallForAllHeaders() (*dsl.Node, error) {
+	receiver := dsl.Variable("all_headers")
+	if p.peek().Type != xTDot {
+		return receiver, nil
+	}
+	if p.lookAhead(1).Type != xTIdent || !isMethodName(p.lookAhead(1).Val) {
+		return receiver, nil
+	}
+	if p.lookAhead(2).Type != xTLParen {
+		return receiver, nil
+	}
+	p.next() // .
+	method := p.next().Val
+	p.next() // (
+	arg, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(xTRParen); err != nil {
+		return nil, err
+	}
+	fn := methodMap[method]
+	if fn == "starts_with" || fn == "ends_with" {
+		fn = "contains"
+	}
+	return dsl.Call(fn, receiver, arg), nil
 }
 
 // maybeRawHeaderCall handles response.raw_header method calls.
@@ -689,6 +766,14 @@ func convertFunctionCall(name string, args []*dsl.Node) *dsl.Node {
 		return dsl.Call("hex_decode", args...)
 	case "hex":
 		return dsl.Call("hex_encode", args...)
+	case "decToHex", "dec_to_hex":
+		return dsl.Call("dec_to_hex", args...)
+	case "rev":
+		return dsl.Call("reverse", args...)
+	case "upper", "toUpper", "to_upper":
+		return dsl.Call("to_upper", args...)
+	case "lower", "toLower", "to_lower":
+		return dsl.Call("to_lower", args...)
 	case "urlencode", "urlEncode", "urlencodeall", "urlEncodeAll", "url_encode":
 		return dsl.Call("url_encode", args...)
 	case "sha":
@@ -748,7 +833,7 @@ func isStringLikeNode(node *dsl.Node) bool {
 		return false
 	}
 	switch node.FuncName {
-	case "to_string", "concat", "base64", "base64_decode", "hex_encode", "hex_decode", "url_encode", "md5", "substr", "rand_base":
+	case "to_string", "concat", "base64", "base64_decode", "hex_encode", "hex_decode", "dec_to_hex", "url_encode", "md5", "substr", "rand_base", "reverse", "to_upper", "to_lower":
 		return true
 	default:
 		return false
@@ -838,6 +923,12 @@ func faviconHashPart(node *dsl.Node) (string, bool) {
 		child := node.Children[0]
 		if child.Type == dsl.NodeCall && child.FuncName == "icon" {
 			return "favicon_hash", true
+		}
+		if child.Type == dsl.NodeVariable {
+			switch child.Value.(string) {
+			case "favicon_content":
+				return "favicon_hash", true
+			}
 		}
 	}
 	return "", false

--- a/convert/path_normalize_test.go
+++ b/convert/path_normalize_test.go
@@ -22,10 +22,10 @@ expression: r0()
 		t.Fatalf("convert: %v", err)
 	}
 	converted := string(out)
-	if strings.Contains(converted, "{{BaseURL}}^/admin") {
+	if strings.Contains(converted, "{{RootURL}}^/admin") {
 		t.Fatalf("path anchor was not stripped:\n%s", converted)
 	}
-	if !strings.Contains(converted, "{{BaseURL}}/admin") {
+	if !strings.Contains(converted, "{{RootURL}}/admin") {
 		t.Fatalf("normalized path missing:\n%s", converted)
 	}
 }

--- a/convert/sequential_convert_test.go
+++ b/convert/sequential_convert_test.go
@@ -39,10 +39,10 @@ expression: create() && check_created() && delete() && check_deleted()
 		t.Fatalf("convert: %v", err)
 	}
 	converted := string(out)
-	if got := strings.Count(converted, "{{BaseURL}}/toggle"); got != 2 {
+	if got := strings.Count(converted, "{{RootURL}}/toggle"); got != 2 {
 		t.Fatalf("expected two toggle requests, got %d:\n%s", got, converted)
 	}
-	if got := strings.Count(converted, "{{BaseURL}}/flag"); got != 2 {
+	if got := strings.Count(converted, "{{RootURL}}/flag"); got != 2 {
 		t.Fatalf("expected two flag requests, got %d:\n%s", got, converted)
 	}
 	if !strings.Contains(converted, "status_code_2 == 200") || !strings.Contains(converted, "status_code == 404") {

--- a/convert/set_variables_test.go
+++ b/convert/set_variables_test.go
@@ -3,6 +3,9 @@ package convert
 import (
 	"strings"
 	"testing"
+
+	"github.com/chainreactors/neutron/templates"
+	"gopkg.in/yaml.v3"
 )
 
 func TestConvertSetVariablesOrdersDependenciesAndMapsHex(t *testing.T) {
@@ -62,6 +65,185 @@ expression: r0()
 	if strings.Contains(converted, "variables:") {
 		t.Fatalf("RootURL should use neutron builtin instead of set variable:\n%s", converted)
 	}
+	if strings.Contains(converted, "xray_RootURL") {
+		t.Fatalf("RootURL builtin should not be rewritten to a missing alias:\n%s", converted)
+	}
+	if !strings.Contains(converted, "Origin: '{{RootURL}}'") {
+		t.Fatalf("expected RootURL placeholder to keep neutron builtin:\n%s", converted)
+	}
+}
+
+func TestConvertRenamesBuiltinSetVariable(t *testing.T) {
+	xray := `
+name: builtin-variable-collision
+transport: http
+set:
+  BaseURL: request.url.domain
+rules:
+  r0:
+    request:
+      method: POST
+      path: /admin/auth/reset-password
+      headers:
+        Origin: https://{{BaseURL}}
+    expression: response.status == 200
+expression: r0()
+`
+	out, err := Convert([]byte(xray))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	converted := string(out)
+	if strings.Contains(converted, "\n  BaseURL:") {
+		t.Fatalf("xray set variable should not override neutron BaseURL:\n%s", converted)
+	}
+	if !strings.Contains(converted, "xray_BaseURL: '{{Host}}'") {
+		t.Fatalf("expected colliding set variable to be renamed:\n%s", converted)
+	}
+	if !strings.Contains(converted, "Origin: https://{{xray_BaseURL}}") {
+		t.Fatalf("expected original header placeholder to use renamed variable:\n%s", converted)
+	}
+	if !strings.Contains(converted, "{{BaseURL}}/admin/auth/reset-password") {
+		t.Fatalf("expected converted request path to keep neutron BaseURL builtin:\n%s", converted)
+	}
+}
+
+func TestConvertBuiltinSetVariableCanReferenceTargetBuiltin(t *testing.T) {
+	xray := `
+name: builtin-variable-target-reference
+transport: http
+set:
+  Hostname: request.url.host
+rules:
+  r0:
+    request:
+      method: GET
+      path: /maint/index.php
+      headers:
+        Referer: '{{Hostname}}/maint/index.php'
+    expression: response.status == 200
+expression: r0()
+`
+	out, err := Convert([]byte(xray))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	converted := string(out)
+	if !strings.Contains(converted, "xray_Hostname: '{{Hostname}}'") {
+		t.Fatalf("expected aliased xray variable to reference neutron Hostname builtin:\n%s", converted)
+	}
+	if strings.Contains(converted, "xray_Hostname: '{{xray_Hostname}}'") {
+		t.Fatalf("aliased set variable should not reference itself:\n%s", converted)
+	}
+	if !strings.Contains(converted, "Referer: '{{xray_Hostname}}/maint/index.php'") {
+		t.Fatalf("expected original placeholder to use aliased variable:\n%s", converted)
+	}
+	assertConvertedCompiles(t, out)
+}
+
+func TestConvertSetStringLiteralAndUpperFunction(t *testing.T) {
+	xray := `
+name: set-string-upper
+transport: http
+set:
+  eps_path: string("/eps/api/resourceOperations/uploadsecretKeyIbuilding")
+  token: upper(md5(eps_path))
+rules:
+  r0:
+    request:
+      method: GET
+      path: /upload?token={{token}}
+    expression: response.status == 200
+expression: r0()
+`
+	out, err := Convert([]byte(xray))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	converted := string(out)
+	if strings.Contains(converted, `eps_path: string(`) {
+		t.Fatalf("string() set expression should become a literal:\n%s", converted)
+	}
+	if !strings.Contains(converted, `eps_path: /eps/api/resourceOperations/uploadsecretKeyIbuilding`) {
+		t.Fatalf("expected string() literal value in variables:\n%s", converted)
+	}
+	if strings.Contains(converted, `{{upper(`) {
+		t.Fatalf("upper() should be translated to neutron DSL:\n%s", converted)
+	}
+	if !strings.Contains(converted, `token: '{{to_upper(md5(eps_path))}}'`) {
+		t.Fatalf("expected upper() to become to_upper():\n%s", converted)
+	}
+}
+
+func TestConvertRevFunction(t *testing.T) {
+	xray := `
+name: rev-function
+transport: http
+set:
+  s1: randomLowercase(8)
+rules:
+  r0:
+    request:
+      method: GET
+      path: /
+    expression: response.status == 200 && response.body_string.contains(rev(s1))
+expression: r0()
+`
+	out, err := Convert([]byte(xray))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	converted := string(out)
+	if strings.Contains(converted, `rev(s1)`) {
+		t.Fatalf("rev() should be translated to neutron DSL:\n%s", converted)
+	}
+	if !strings.Contains(converted, `contains(body, reverse(s1))`) {
+		t.Fatalf("expected rev() to become reverse():\n%s", converted)
+	}
+}
+
+func TestConvertAliasesReservedOutputVariable(t *testing.T) {
+	xray := `
+name: output-reserved-variable
+transport: http
+rules:
+  r0:
+    request:
+      method: GET
+      path: /
+    expression: response.status == 200
+    output:
+      len: size(response.body)
+      total: int(len / 2)
+      hexed: decToHex(total)
+  r1:
+    request:
+      method: GET
+      path: /next/{{hexed}}
+    expression: response.status == 200
+expression: r0() && r1()
+`
+	out, err := Convert([]byte(xray))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	converted := string(out)
+	if strings.Contains(converted, "\n          name: len\n") {
+		t.Fatalf("reserved output variable should be renamed:\n%s", converted)
+	}
+	if !strings.Contains(converted, "name: xray_len") {
+		t.Fatalf("expected len output variable to be aliased:\n%s", converted)
+	}
+	if strings.Contains(converted, "xray_div(len, 2)") {
+		t.Fatalf("reserved output variable reference was not aliased:\n%s", converted)
+	}
+	if !strings.Contains(converted, "xray_div(xray_len, 2)") {
+		t.Fatalf("expected output expression to reference aliased variable:\n%s", converted)
+	}
+	if !strings.Contains(converted, "dec_to_hex(total)") {
+		t.Fatalf("expected decToHex() to become dec_to_hex():\n%s", converted)
+	}
+	assertConvertedCompiles(t, out)
 }
 
 func TestConvertSetBytesVariableExpression(t *testing.T) {
@@ -89,5 +271,16 @@ expression: r0()
 	}
 	if !strings.Contains(converted, `token_bytes: '{{token}}'`) {
 		t.Fatalf("expected bytes(token) to reference token variable:\n%s", converted)
+	}
+}
+
+func assertConvertedCompiles(t *testing.T, out []byte) {
+	t.Helper()
+	var tmpl templates.Template
+	if err := yaml.Unmarshal(out, &tmpl); err != nil {
+		t.Fatalf("unmarshal converted template: %v\n%s", err, out)
+	}
+	if err := tmpl.Compile(nil); err != nil {
+		t.Fatalf("compile converted template: %v\n%s", err, out)
 	}
 }

--- a/convert/set_variables_test.go
+++ b/convert/set_variables_test.go
@@ -103,8 +103,8 @@ expression: r0()
 	if !strings.Contains(converted, "Origin: https://{{xray_BaseURL}}") {
 		t.Fatalf("expected original header placeholder to use renamed variable:\n%s", converted)
 	}
-	if !strings.Contains(converted, "{{BaseURL}}/admin/auth/reset-password") {
-		t.Fatalf("expected converted request path to keep neutron BaseURL builtin:\n%s", converted)
+	if !strings.Contains(converted, "{{RootURL}}/admin/auth/reset-password") {
+		t.Fatalf("expected converted request path to use RootURL:\n%s", converted)
 	}
 }
 

--- a/harness/harness_test.go
+++ b/harness/harness_test.go
@@ -37,6 +37,51 @@ expression: r0()
 	require.True(t, report.Matched)
 }
 
+func TestVerifyUnsupportedImpossibleHTTPStatus(t *testing.T) {
+	raw := `
+name: harness-impossible-status
+transport: http
+rules:
+  r0:
+    request:
+      method: GET
+      path: /status
+    expression: response.status < 2
+expression: r0()
+`
+	report := VerifyFile(&POCFile{Path: "status.yml", Data: []byte(raw), POC: loadTestPOC(t, raw)}, VerifyOptions{})
+	require.Equal(t, StatusUnsupported, report.Status)
+	require.Contains(t, report.Unsupported, "cannot generate valid HTTP status for response.status < 2")
+}
+
+func TestChooseStatusCodeSolvesHTTPRange(t *testing.T) {
+	tests := []struct {
+		op     string
+		target int
+		want   int
+		ok     bool
+	}{
+		{op: "==", target: 200, want: 200, ok: true},
+		{op: "!=", target: 200, want: 201, ok: true},
+		{op: "!=", target: 700, want: 200, ok: true},
+		{op: ">", target: 99, want: 100, ok: true},
+		{op: ">", target: 599, ok: false},
+		{op: ">=", target: 0, want: 100, ok: true},
+		{op: "<", target: 101, want: 100, ok: true},
+		{op: "<", target: 2, ok: false},
+		{op: "<=", target: 700, want: 599, ok: true},
+		{op: "<=", target: 99, ok: false},
+	}
+
+	for _, tt := range tests {
+		got, ok := chooseStatusCode(tt.op, tt.target)
+		require.Equal(t, tt.ok, ok, "%s %d", tt.op, tt.target)
+		if tt.ok {
+			require.Equal(t, tt.want, got, "%s %d", tt.op, tt.target)
+		}
+	}
+}
+
 func TestVerifyOutputVariablePathChain(t *testing.T) {
 	raw := `
 name: harness-output-chain

--- a/harness/mutate.go
+++ b/harness/mutate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"html"
+	"net/http"
 	"net/url"
 	"regexp"
 	"sort"
@@ -87,11 +88,17 @@ func buildRoute(ruleName string, rule *convert.XrayRule, values map[string]strin
 	outputUnsupported := applyOutputs(rule.Output, resp, values)
 	unsupported = append(unsupported, outputUnsupported...)
 
+	pathPattern, err := templateRegexp(reqPath, values, wildcards, true)
+	if err != nil {
+		unsupported = append(unsupported, "request path pattern unsupported: "+err.Error())
+		return nil, unsupported
+	}
+
 	route := &Route{
 		Rule:         ruleName,
 		Method:       strings.ToUpper(method),
 		PathTemplate: reqPath,
-		Path:         templateRegexp(reqPath, values, wildcards, true),
+		Path:         pathPattern,
 		Headers:      map[string]*Pattern{},
 		Response:     resp,
 	}
@@ -114,10 +121,20 @@ func buildRoute(ruleName string, rule *convert.XrayRule, values map[string]strin
 		return dynamicResp, outputs
 	}
 	if strings.TrimSpace(rule.Request.Body) != "" {
-		route.Body = templateRegexp(rule.Request.Body, values, wildcards, false)
+		bodyPattern, err := templateRegexp(rule.Request.Body, values, wildcards, false)
+		if err != nil {
+			unsupported = append(unsupported, "request body pattern unsupported: "+err.Error())
+		} else {
+			route.Body = bodyPattern
+		}
 	}
 	for k, v := range rule.Request.Headers {
-		route.Headers[strings.ToLower(k)] = templateRegexp(v, values, wildcards, false)
+		headerPattern, err := templateRegexp(v, values, wildcards, false)
+		if err != nil {
+			unsupported = append(unsupported, "request header pattern unsupported: "+err.Error())
+			continue
+		}
+		route.Headers[strings.ToLower(k)] = headerPattern
 	}
 	return route, unsupported
 }
@@ -254,7 +271,12 @@ func mutateComparison(node *dsl.Node, resp *ResponseSpec, hints groupHints, opt 
 	left, right := node.Children[0], node.Children[1]
 	if isStatusVar(left) {
 		if n, ok := literalInt(right); ok {
-			resp.StatusCode = chooseNumber(node.Op, n)
+			status, valid := chooseStatusCode(node.Op, n)
+			if !valid {
+				*unsupported = append(*unsupported, fmt.Sprintf("cannot generate valid HTTP status for response.status %s %d", node.Op, n))
+				return
+			}
+			resp.StatusCode = status
 			return
 		}
 	}
@@ -1291,6 +1313,64 @@ func chooseNumber(op string, target int) int {
 	}
 }
 
+func chooseStatusCode(op string, target int) (int, bool) {
+	const (
+		minStatus = 100
+		maxStatus = 599
+	)
+
+	switch op {
+	case "==":
+		if target < minStatus || target > maxStatus {
+			return 0, false
+		}
+		return target, true
+	case "!=":
+		if target != http.StatusOK {
+			return http.StatusOK, true
+		}
+		return http.StatusCreated, true
+	case ">":
+		status := target + 1
+		if status < minStatus {
+			status = minStatus
+		}
+		if status > maxStatus {
+			return 0, false
+		}
+		return status, true
+	case ">=":
+		status := target
+		if status < minStatus {
+			status = minStatus
+		}
+		if status > maxStatus {
+			return 0, false
+		}
+		return status, true
+	case "<":
+		status := target - 1
+		if status > maxStatus {
+			status = maxStatus
+		}
+		if status < minStatus {
+			return 0, false
+		}
+		return status, true
+	case "<=":
+		status := target
+		if status > maxStatus {
+			status = maxStatus
+		}
+		if status < minStatus {
+			return 0, false
+		}
+		return status, true
+	default:
+		return 0, false
+	}
+}
+
 func chooseDelay(op string, target float64, millis bool) time.Duration {
 	unit := time.Second
 	if millis {
@@ -1357,7 +1437,7 @@ func parseFloat(value interface{}) (float64, bool) {
 	}
 }
 
-func templateRegexp(tmpl string, values map[string]string, wildcards map[string]bool, forPath bool) *Pattern {
+func templateRegexp(tmpl string, values map[string]string, wildcards map[string]bool, forPath bool) (*Pattern, error) {
 	var b strings.Builder
 	b.WriteString("^")
 	last := 0
@@ -1388,7 +1468,11 @@ func templateRegexp(tmpl string, values map[string]string, wildcards map[string]
 	}
 	b.WriteString(regexp.QuoteMeta(tmpl[last:]))
 	b.WriteString("$")
-	return &Pattern{Re: regexp.MustCompile(b.String()), Groups: groups}
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil, err
+	}
+	return &Pattern{Re: re, Groups: groups}, nil
 }
 
 func captureName(name string, index int) string {

--- a/protocols/generators.go
+++ b/protocols/generators.go
@@ -2,8 +2,10 @@ package protocols
 
 import (
 	"errors"
-	"github.com/chainreactors/neutron/common"
+	"sort"
 	"strings"
+
+	"github.com/chainreactors/neutron/common"
 )
 
 // Inspired from https://github.com/ffuf/ffuf/blob/master/pkg/input/input.go
@@ -77,11 +79,11 @@ func NewGenerator(payloads map[string]interface{}, payloadType Type) (*Generator
 	// Validate the payload types
 	if payloadType == PitchFork {
 		var totalLength int
-		for v := range compiled {
-			if totalLength != 0 && totalLength != len(v) {
+		for _, values := range compiled {
+			if totalLength != 0 && totalLength != len(values) {
 				return nil, errors.New("pitchfork payloads must be of equal number")
 			}
-			totalLength = len(v)
+			totalLength = len(values)
 		}
 	}
 	return generator, nil
@@ -98,10 +100,15 @@ type Iterator struct {
 
 // NewIterator creates a new iterator for the payloads generator
 func (g *Generator) NewIterator() *Iterator {
-	var payloads []*payloadIterator
+	names := make([]string, 0, len(g.payloads))
+	for name := range g.payloads {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 
-	for name, values := range g.payloads {
-		payloads = append(payloads, &payloadIterator{name: name, values: values})
+	payloads := make([]*payloadIterator, 0, len(names))
+	for _, name := range names {
+		payloads = append(payloads, &payloadIterator{name: name, values: g.payloads[name]})
 	}
 	iterator := &Iterator{
 		Type:     g.Type,
@@ -135,7 +142,11 @@ func (i *Iterator) Total() int {
 			count += len(p.values)
 		}
 	case PitchFork:
-		count = len(i.payloads[0].values)
+		if len(i.payloads) == 0 {
+			count = 0
+		} else {
+			count = len(i.payloads[0].values)
+		}
 	case ClusterBomb:
 		count = 1
 		for _, p := range i.payloads {

--- a/protocols/generators_test.go
+++ b/protocols/generators_test.go
@@ -1,0 +1,99 @@
+package protocols
+
+import (
+	"testing"
+)
+
+func TestPitchforkValidation(t *testing.T) {
+	_, err := NewGenerator(map[string]interface{}{
+		"a": []string{"1", "2", "3"},
+		"b": []string{"x", "y"},
+	}, PitchFork)
+	if err == nil {
+		t.Fatal("expected error for unequal pitchfork payload lengths")
+	}
+}
+
+func TestPitchforkEqualLength(t *testing.T) {
+	gen, err := NewGenerator(map[string]interface{}{
+		"a": []string{"1", "2"},
+		"b": []string{"x", "y"},
+	}, PitchFork)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	iter := gen.NewIterator()
+	if iter.Total() != 2 {
+		t.Fatalf("expected total 2, got %d", iter.Total())
+	}
+
+	v1, ok := iter.Value()
+	if !ok {
+		t.Fatal("expected first value")
+	}
+	if v1["a"] != "1" || v1["b"] != "x" {
+		t.Fatalf("expected a=1,b=x, got a=%v,b=%v", v1["a"], v1["b"])
+	}
+
+	v2, ok := iter.Value()
+	if !ok {
+		t.Fatal("expected second value")
+	}
+	if v2["a"] != "2" || v2["b"] != "y" {
+		t.Fatalf("expected a=2,b=y, got a=%v,b=%v", v2["a"], v2["b"])
+	}
+
+	_, ok = iter.Value()
+	if ok {
+		t.Fatal("expected no more values")
+	}
+}
+
+func TestPitchforkDeterministicOrder(t *testing.T) {
+	payloads := map[string]interface{}{
+		"z": []string{"z1", "z2"},
+		"a": []string{"a1", "a2"},
+		"m": []string{"m1", "m2"},
+	}
+
+	for i := 0; i < 20; i++ {
+		gen, err := NewGenerator(payloads, PitchFork)
+		if err != nil {
+			t.Fatalf("run %d: unexpected error: %v", i, err)
+		}
+		iter := gen.NewIterator()
+		v, ok := iter.Value()
+		if !ok {
+			t.Fatalf("run %d: expected value", i)
+		}
+		if v["a"] != "a1" || v["m"] != "m1" || v["z"] != "z1" {
+			t.Fatalf("run %d: expected a=a1,m=m1,z=z1, got a=%v,m=%v,z=%v", i, v["a"], v["m"], v["z"])
+		}
+	}
+}
+
+func TestPitchforkEmptyPayloads(t *testing.T) {
+	gen, err := NewGenerator(map[string]interface{}{}, PitchFork)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	iter := gen.NewIterator()
+	if iter.Total() != 0 {
+		t.Fatalf("expected total 0, got %d", iter.Total())
+	}
+}
+
+func TestClusterBombValues(t *testing.T) {
+	gen, err := NewGenerator(map[string]interface{}{
+		"a": []string{"1", "2"},
+		"b": []string{"x", "y"},
+	}, ClusterBomb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	iter := gen.NewIterator()
+	if iter.Total() != 4 {
+		t.Fatalf("expected total 4, got %d", iter.Total())
+	}
+}

--- a/protocols/http/request_generator.go
+++ b/protocols/http/request_generator.go
@@ -143,13 +143,27 @@ func (r *requestGenerator) Make(baseURL, reqdata string, payloads, dynamicValues
 	reqdata, parsed = baseURLWithTemplatePrefs(reqdata, parsed)
 	isRawRequest := len(r.request.Raw) > 0
 
+	// Deduplicate overlapping path prefix between target URL and template path.
+	// e.g. target=http://x/druid/ + template={{BaseURL}}/druid/index.html
+	//   → without dedup: /druid/druid/index.html (wrong)
+	//   → with dedup:    /druid/index.html (correct, matches xpoc behavior)
+	parsed = deduplicateBaseURLPath(parsed, reqdata)
+
 	trailingSlash := false
 	if !isRawRequest && strings.HasSuffix(parsed.Path, "/") && strings.Contains(reqdata, "{{BaseURL}}/") {
 		trailingSlash = true
 	}
-	values := common.MergeMaps(globalValues, generateVariables(parsed, trailingSlash))
-	values = common.MergeMaps(values, allVars)
-	reqdata, err = common.Evaluate(reqdata, values)
+	targetValues := common.MergeMaps(globalValues, generateVariables(parsed, trailingSlash))
+	values := common.MergeMaps(targetValues, allVars)
+	if r.request.options != nil && r.request.options.Variables.Len() > 0 {
+		variablesMap := r.request.options.Variables.Evaluate(values)
+		if len(variablesMap) > 0 {
+			allVars = common.MergeMaps(allVars, variablesMap)
+			dynamicValues = common.MergeMaps(dynamicValues, variablesMap)
+			values = common.MergeMaps(values, variablesMap)
+		}
+	}
+	reqdata, err = common.Evaluate(reqdata, common.MergeMaps(values, targetValues))
 	if err != nil {
 		return nil, err
 	}
@@ -308,6 +322,49 @@ func setHeader(req *http.Request, name, value string) {
 	if name == "Host" {
 		req.Host = value
 	}
+}
+
+// deduplicateBaseURLPath strips the target URL's path when the template path
+// shares a leading directory with it, preventing doubled segments like /druid/druid/.
+// Only acts when the template uses {{BaseURL}}/... and the target has a non-root path.
+func deduplicateBaseURLPath(parsed *url.URL, reqdata string) *url.URL {
+	targetPath := strings.TrimRight(parsed.Path, "/")
+	if targetPath == "" {
+		return parsed
+	}
+	idx := strings.Index(reqdata, "{{BaseURL}}/")
+	if idx < 0 {
+		return parsed
+	}
+	templateSuffix := reqdata[idx+len("{{BaseURL}}"):]
+	if i := strings.IndexAny(templateSuffix, "\"' \t\n}"); i > 0 {
+		templateSuffix = templateSuffix[:i]
+	}
+	// Find the first path segment of the template path: /druid/... → druid
+	templateSuffix = strings.TrimLeft(templateSuffix, "/")
+	firstSeg := templateSuffix
+	if i := strings.IndexAny(firstSeg, "/?"); i > 0 {
+		firstSeg = firstSeg[:i]
+	}
+	if firstSeg == "" {
+		return parsed
+	}
+	// Check if any segment in the target path matches the template's first segment.
+	// Keep everything before the matching segment so deeper prefixes survive.
+	targetSegs := strings.Split(strings.Trim(targetPath, "/"), "/")
+	for i, seg := range targetSegs {
+		if seg == firstSeg {
+			clone := *parsed
+			if i == 0 {
+				clone.Path = ""
+			} else {
+				clone.Path = "/" + strings.Join(targetSegs[:i], "/")
+			}
+			clone.RawPath = ""
+			return &clone
+		}
+	}
+	return parsed
 }
 
 // generateVariables will create default variables after parsing a url

--- a/protocols/http/request_generator.go
+++ b/protocols/http/request_generator.go
@@ -143,12 +143,6 @@ func (r *requestGenerator) Make(baseURL, reqdata string, payloads, dynamicValues
 	reqdata, parsed = baseURLWithTemplatePrefs(reqdata, parsed)
 	isRawRequest := len(r.request.Raw) > 0
 
-	// Deduplicate overlapping path prefix between target URL and template path.
-	// e.g. target=http://x/druid/ + template={{BaseURL}}/druid/index.html
-	//   → without dedup: /druid/druid/index.html (wrong)
-	//   → with dedup:    /druid/index.html (correct, matches xpoc behavior)
-	parsed = deduplicateBaseURLPath(parsed, reqdata)
-
 	trailingSlash := false
 	if !isRawRequest && strings.HasSuffix(parsed.Path, "/") && strings.Contains(reqdata, "{{BaseURL}}/") {
 		trailingSlash = true
@@ -322,49 +316,6 @@ func setHeader(req *http.Request, name, value string) {
 	if name == "Host" {
 		req.Host = value
 	}
-}
-
-// deduplicateBaseURLPath strips the target URL's path when the template path
-// shares a leading directory with it, preventing doubled segments like /druid/druid/.
-// Only acts when the template uses {{BaseURL}}/... and the target has a non-root path.
-func deduplicateBaseURLPath(parsed *url.URL, reqdata string) *url.URL {
-	targetPath := strings.TrimRight(parsed.Path, "/")
-	if targetPath == "" {
-		return parsed
-	}
-	idx := strings.Index(reqdata, "{{BaseURL}}/")
-	if idx < 0 {
-		return parsed
-	}
-	templateSuffix := reqdata[idx+len("{{BaseURL}}"):]
-	if i := strings.IndexAny(templateSuffix, "\"' \t\n}"); i > 0 {
-		templateSuffix = templateSuffix[:i]
-	}
-	// Find the first path segment of the template path: /druid/... → druid
-	templateSuffix = strings.TrimLeft(templateSuffix, "/")
-	firstSeg := templateSuffix
-	if i := strings.IndexAny(firstSeg, "/?"); i > 0 {
-		firstSeg = firstSeg[:i]
-	}
-	if firstSeg == "" {
-		return parsed
-	}
-	// Check if any segment in the target path matches the template's first segment.
-	// Keep everything before the matching segment so deeper prefixes survive.
-	targetSegs := strings.Split(strings.Trim(targetPath, "/"), "/")
-	for i, seg := range targetSegs {
-		if seg == firstSeg {
-			clone := *parsed
-			if i == 0 {
-				clone.Path = ""
-			} else {
-				clone.Path = "/" + strings.Join(targetSegs[:i], "/")
-			}
-			clone.RawPath = ""
-			return &clone
-		}
-	}
-	return parsed
 }
 
 // generateVariables will create default variables after parsing a url

--- a/protocols/variables_json.go
+++ b/protocols/variables_json.go
@@ -4,6 +4,9 @@
 package protocols
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/chainreactors/neutron/common"
 )
 
@@ -25,10 +28,33 @@ func (variables *Variable) Evaluate(values map[string]interface{}) map[string]in
 // evaluateVariableValue expression and returns final value
 func evaluateVariableValue(expression string, values, processing map[string]interface{}) string {
 	finalMap := common.MergeMaps(values, processing)
+	if hasUnresolvedVariableDependency(expression, finalMap) {
+		return expression
+	}
 
 	result, err := common.Evaluate(expression, finalMap)
 	if err != nil {
 		return expression
 	}
 	return result
+}
+
+var variableDependencyRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
+
+func hasUnresolvedVariableDependency(expression string, values map[string]interface{}) bool {
+	if !strings.Contains(expression, common.ParenthesisOpen) {
+		return false
+	}
+	for _, expr := range common.FindExpressions(expression, common.ParenthesisOpen, common.ParenthesisClose, values) {
+		for _, ident := range variableDependencyRE.FindAllString(expr, -1) {
+			value, ok := values[ident]
+			if !ok {
+				continue
+			}
+			if strings.Contains(common.ToString(value), common.ParenthesisOpen) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/protocols/variables_json.go
+++ b/protocols/variables_json.go
@@ -4,9 +4,6 @@
 package protocols
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/chainreactors/neutron/common"
 )
 
@@ -28,33 +25,10 @@ func (variables *Variable) Evaluate(values map[string]interface{}) map[string]in
 // evaluateVariableValue expression and returns final value
 func evaluateVariableValue(expression string, values, processing map[string]interface{}) string {
 	finalMap := common.MergeMaps(values, processing)
-	if hasUnresolvedVariableDependency(expression, finalMap) {
-		return expression
-	}
 
 	result, err := common.Evaluate(expression, finalMap)
 	if err != nil {
 		return expression
 	}
 	return result
-}
-
-var variableDependencyRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
-
-func hasUnresolvedVariableDependency(expression string, values map[string]interface{}) bool {
-	if !strings.Contains(expression, common.ParenthesisOpen) {
-		return false
-	}
-	for _, expr := range common.FindExpressions(expression, common.ParenthesisOpen, common.ParenthesisClose, values) {
-		for _, ident := range variableDependencyRE.FindAllString(expr, -1) {
-			value, ok := values[ident]
-			if !ok {
-				continue
-			}
-			if strings.Contains(common.ToString(value), common.ParenthesisOpen) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/protocols/variables_yaml.go
+++ b/protocols/variables_yaml.go
@@ -5,8 +5,6 @@ package protocols
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/chainreactors/neutron/common"
 	"gopkg.in/yaml.v3"
@@ -80,46 +78,16 @@ func (variables *Variable) Evaluate(values map[string]interface{}) map[string]in
 
 func (variables *Variable) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	variables.InsertionOrderedStringMap = InsertionOrderedStringMap{}
-	if err := unmarshal(&variables.InsertionOrderedStringMap); err != nil {
-		return err
-	}
-	evaluated := variables.Evaluate(map[string]interface{}{})
-	for k, v := range evaluated {
-		variables.Set(k, v)
-	}
-	return nil
+	return unmarshal(&variables.InsertionOrderedStringMap)
 }
 
 // evaluateVariableValue expression and returns final value
 func evaluateVariableValue(expression string, values, processing map[string]interface{}) string {
 	finalMap := common.MergeMaps(values, processing)
-	if hasUnresolvedVariableDependency(expression, finalMap) {
-		return expression
-	}
 
 	result, err := common.Evaluate(expression, finalMap)
 	if err != nil {
 		return expression
 	}
 	return result
-}
-
-var variableDependencyRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
-
-func hasUnresolvedVariableDependency(expression string, values map[string]interface{}) bool {
-	if !strings.Contains(expression, common.ParenthesisOpen) {
-		return false
-	}
-	for _, expr := range common.FindExpressions(expression, common.ParenthesisOpen, common.ParenthesisClose, values) {
-		for _, ident := range variableDependencyRE.FindAllString(expr, -1) {
-			value, ok := values[ident]
-			if !ok {
-				continue
-			}
-			if strings.Contains(common.ToString(value), common.ParenthesisOpen) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/protocols/variables_yaml.go
+++ b/protocols/variables_yaml.go
@@ -5,6 +5,9 @@ package protocols
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/chainreactors/neutron/common"
 	"gopkg.in/yaml.v3"
 )
@@ -90,10 +93,33 @@ func (variables *Variable) UnmarshalYAML(unmarshal func(interface{}) error) erro
 // evaluateVariableValue expression and returns final value
 func evaluateVariableValue(expression string, values, processing map[string]interface{}) string {
 	finalMap := common.MergeMaps(values, processing)
+	if hasUnresolvedVariableDependency(expression, finalMap) {
+		return expression
+	}
 
 	result, err := common.Evaluate(expression, finalMap)
 	if err != nil {
 		return expression
 	}
 	return result
+}
+
+var variableDependencyRE = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*\b`)
+
+func hasUnresolvedVariableDependency(expression string, values map[string]interface{}) bool {
+	if !strings.Contains(expression, common.ParenthesisOpen) {
+		return false
+	}
+	for _, expr := range common.FindExpressions(expression, common.ParenthesisOpen, common.ParenthesisClose, values) {
+		for _, ident := range variableDependencyRE.FindAllString(expr, -1) {
+			value, ok := values[ident]
+			if !ok {
+				continue
+			}
+			if strings.Contains(common.ToString(value), common.ParenthesisOpen) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/templates/request_response_test.go
+++ b/templates/request_response_test.go
@@ -462,6 +462,48 @@ http:
 	_ = hasStep1
 }
 
+func TestExecuteStaticVariableChainWithoutPreEvaluation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/prefix-hello-suffix" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "chain resolved")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "unexpected path: %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	yamlContent := `
+id: static-variable-chain-test
+info:
+  name: Static Variable Chain Test
+  author: test
+  severity: info
+variables:
+  a: hello
+  b: '{{concat("prefix-", a)}}'
+  c: '{{concat(b, "-suffix")}}'
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/{{c}}'
+    matchers:
+      - type: word
+        words:
+          - "chain resolved"
+`
+	var tmpl Template
+	err := yaml.Unmarshal([]byte(yamlContent), &tmpl)
+	require.NoError(t, err)
+	require.NoError(t, tmpl.Compile(nil))
+
+	result, err := tmpl.Execute(server.URL, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Matched)
+}
+
 func containsAll(s string, substrs ...string) bool {
 	for _, sub := range substrs {
 		if !strings.Contains(s, sub) {

--- a/templates/request_response_test.go
+++ b/templates/request_response_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"crypto/md5"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -57,6 +58,105 @@ http:
 	require.NotEmpty(t, result.Response)
 	require.Contains(t, result.Response, "200")
 	require.Contains(t, result.Response, "vulnerable endpoint detected")
+}
+
+func TestExecuteEvaluatesVariablesAfterTargetBuiltins(t *testing.T) {
+	const epsPath = "/eps/api/resourceOperations/uploadsecretKeyIbuilding"
+
+	var gotHost, gotPath, gotToken, expectedToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		sum := md5.Sum([]byte(fmt.Sprintf("%s://%s%s", scheme, r.Host, epsPath)))
+		expectedToken = fmt.Sprintf("%X", sum)
+		gotHost = r.Host
+		gotPath = r.URL.Path
+		gotToken = r.URL.Query().Get("token")
+		if r.URL.Path != "/eps/api/resourceOperations/upload" || r.URL.Query().Get("token") != expectedToken {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "path=%s token=%s expected=%s", r.URL.Path, r.URL.Query().Get("token"), expectedToken)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "token accepted")
+	}))
+	defer server.Close()
+
+	yamlContent := `
+id: target-builtin-variable-test
+info:
+  name: Target Builtin Variable Test
+  author: test
+  severity: info
+variables:
+  eps_path: /eps/api/resourceOperations/uploadsecretKeyIbuilding
+  host: '{{Hostname}}'
+  scheme: '{{Scheme}}'
+  url: '{{concat(concat(concat(scheme, "://"), host), eps_path)}}'
+  token: '{{to_upper(md5(url))}}'
+http:
+  - method: GET
+    path:
+      - '{{BaseURL}}/eps/api/resourceOperations/upload?token={{token}}'
+    matchers:
+      - type: word
+        words:
+          - "token accepted"
+`
+	var tmpl Template
+	err := yaml.Unmarshal([]byte(yamlContent), &tmpl)
+	require.NoError(t, err)
+	require.NoError(t, tmpl.Compile(nil))
+
+	result, err := tmpl.Execute(server.URL, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result, "host=%s path=%s token=%s expected=%s", gotHost, gotPath, gotToken, expectedToken)
+	require.True(t, result.Matched)
+}
+
+func TestExecuteUsesTargetBaseURLForRequestPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedOrigin := "https://" + strings.Split(r.Host, ":")[0]
+		if r.URL.Path != "/admin/auth/reset-password" || r.Header.Get("Origin") != expectedOrigin {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "path=%s origin=%s expected=%s", r.URL.Path, r.Header.Get("Origin"), expectedOrigin)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "strapi ok")
+	}))
+	defer server.Close()
+
+	yamlContent := `
+id: builtin-baseurl-path-test
+info:
+  name: Builtin BaseURL Path Test
+  author: test
+  severity: info
+variables:
+  BaseURL: '{{Host}}'
+http:
+  - method: POST
+    path:
+      - '{{BaseURL}}/admin/auth/reset-password'
+    headers:
+      Origin: https://{{BaseURL}}
+    matchers:
+      - type: word
+        words:
+          - "strapi ok"
+`
+	var tmpl Template
+	err := yaml.Unmarshal([]byte(yamlContent), &tmpl)
+	require.NoError(t, err)
+	require.NoError(t, tmpl.Compile(nil))
+
+	result, err := tmpl.Execute(server.URL, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Matched)
 }
 
 func TestExecuteNoMatchEmptyRequestResponse(t *testing.T) {


### PR DESCRIPTION
## Summary
- **变量求值顺序修复**：先注入目标内置变量再求值用户 variables，加入链式依赖检查防止提前求值
- **变量名冲突自动重命名**：xray POC 中与 neutron 内置变量/DSL 函数同名的 set/output/payload 变量自动加 `xray_` 前缀
- **codegen 增强**：header 变量生成 `header="key: value"` 查询、多请求历史变量归一化、透明函数包装剥离、`!=` 操作符支持
- **DSL 兼容层扩展**：注册 upper/lower 别名，补充 decToHex/rev/favicon 映射，修复 rand 函数字符串参数 panic
- **harness 状态码约束**：限制 mock 状态码 100-599，正则编译失败返回 error 替代 panic
- **lexer 增强**：支持三引号字符串 `'''...'''`、`\xNN` 十六进制转义、`\n\r\t\0` 转义序列
- **parser 增强**：header 变量索引支持 ident 类型引用

## Test plan
- [ ] `go test ./common/dsl/ -v` — DSL 函数 + codegen 测试
- [ ] `go test ./convert/ -v` — 转换器单元 + 端到端测试
- [ ] `go test ./harness/ -v` — harness 状态码约束测试
- [ ] `go test ./templates/ -v` — 变量求值端到端测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)