### PR TITLE
neutron: cert 字段注册表 + 纯 SSL 协议 + Transport 注入 + r5 bad-case 回归基线

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./operators/ ./protocols/ ./protocols/http/ ./templates/ -v -count=1 -timeout=120s
+        run: go test ./operators/ ./protocols/ ./protocols/http/ ./protocols/ssl/ ./templates/ ./convert/ -short -v -count=1 -timeout=180s
 
       - name: Test JSON build
-        run: go test -tags json ./operators/ ./protocols/ ./protocols/http/ ./templates/ -v -count=1 -timeout=120s
+        run: go test -tags json ./operators/ ./protocols/ ./protocols/http/ ./protocols/ssl/ ./templates/ ./convert/ -short -v -count=1 -timeout=180s

--- a/common/certfields.go
+++ b/common/certfields.go
@@ -1,0 +1,26 @@
+package common
+
+// XrayCertFields maps an xray `response.cert.<sub>` subfield name to the
+// neutron data-map key that the HTTP response populates. This is the single
+// source of truth shared by the converter (which decides what subfields are
+// evaluable) and the HTTP runtime (which fills the keys). Adding a cert field
+// means adding one entry here plus its extractor in protocols/http.
+//
+// Aliases (e.g. cn -> common_name) may point at the same data key.
+var XrayCertFields = map[string]string{
+	"subject":      "cert_subject",
+	"issuer":       "cert_issuer",
+	"not_before":   "cert_not_before",
+	"not_after":    "cert_not_after",
+	"dnsnames":     "cert_dnsnames",
+	"serial":       "cert_serial",
+	"common_name":  "cert_common_name",
+	"cn":           "cert_common_name",
+	"organization": "cert_organization",
+	"org":          "cert_organization",
+}
+
+// RawCertKey is the data-map key holding the concatenated raw DER bytes of the
+// peer certificate chain. xray's `response.raw_cert.bcontains(...)` matches
+// against this (printable strings in DER are stored as literal ASCII).
+const RawCertKey = "raw_cert"

--- a/convert/badcase_finger_test.go
+++ b/convert/badcase_finger_test.go
@@ -1,0 +1,151 @@
+package convert
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chainreactors/neutron/protocols"
+	"github.com/chainreactors/neutron/templates"
+	"gopkg.in/yaml.v3"
+)
+
+// TestBadCaseFinger_R5_Compile 守住 SDK v0.2.4 实跑里出现的 22 个 bad-case
+// 指纹 YAML 至少能被 Convert+Compile 处理掉,不留 panic / 不返 error。
+// 这条 case 是离线的(无网络),CI 默认跑这条。
+//
+// 实测命中率验证在 TestBadCaseFinger_R5_LiveTargets,默认 -short 跳过。
+func TestBadCaseFinger_R5_Compile(t *testing.T) {
+	dir := "testdata/badcase_finger_r5_20260608"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read testdata dir: %v", err)
+	}
+	yamlCount := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		yamlCount++
+		t.Run(e.Name(), func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			converted, err := Convert(raw)
+			if err != nil {
+				t.Fatalf("convert: %v", err)
+			}
+			var tmpl templates.Template
+			if err := yaml.Unmarshal(converted, &tmpl); err != nil {
+				t.Fatalf("unmarshal converted template: %v\n%s", err, converted)
+			}
+			if err := tmpl.Compile(nil); err != nil {
+				t.Fatalf("compile converted template: %v\n%s", err, converted)
+			}
+		})
+	}
+	if yamlCount == 0 {
+		t.Fatalf("no yaml files found under %s", dir)
+	}
+}
+
+// TestBadCaseFinger_R5_LiveTargets 拉 testdata/.../urls.tsv 里每个 URL 实跑一次,
+// 把当前命中数 vs r5 基线打到测试输出。**不会** 因命中数下降而 fail——回归对比
+// 在脚本侧做,这里只是把数据落到 CI 日志里给 reviewer 看。
+//
+// 默认 -short 模式跳过(CI 不联网);手动复现用 `go test -run BadCaseFinger -timeout 30m`。
+func TestBadCaseFinger_R5_LiveTargets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("live network test; pass -timeout 30m and unset -short to run")
+	}
+	dir := "testdata/badcase_finger_r5_20260608"
+	urlsPath := filepath.Join(dir, "urls.tsv")
+	rows, err := loadBadCaseURLs(urlsPath)
+	if err != nil {
+		t.Fatalf("load urls.tsv: %v", err)
+	}
+	// 按 yaml_file 分组,每个 yaml 只 Convert+Compile 一次,然后扫一遍它的 URL。
+	byFile := map[string][]badCaseRow{}
+	for _, r := range rows {
+		byFile[r.YAMLFile] = append(byFile[r.YAMLFile], r)
+	}
+	for fname, group := range byFile {
+		t.Run(fname, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, fname))
+			if err != nil {
+				t.Fatalf("read %s: %v", fname, err)
+			}
+			converted, err := Convert(raw)
+			if err != nil {
+				t.Fatalf("convert %s: %v", fname, err)
+			}
+			var tmpl templates.Template
+			if err := yaml.Unmarshal(converted, &tmpl); err != nil {
+				t.Fatalf("unmarshal %s: %v", fname, err)
+			}
+			if err := tmpl.Compile(&protocols.ExecuterOptions{Options: &protocols.Options{Timeout: 8}}); err != nil {
+				t.Fatalf("compile %s: %v", fname, err)
+			}
+			var nowHit, r5Hit int
+			for _, row := range group {
+				if row.R5Match {
+					r5Hit++
+				}
+				deadline := time.Now().Add(30 * time.Second)
+				resultCh := make(chan bool, 1)
+				go func(url string) {
+					res, _ := tmpl.Execute(url, nil)
+					resultCh <- res != nil && res.Matched
+				}(row.URL)
+				select {
+				case ok := <-resultCh:
+					if ok {
+						nowHit++
+					}
+				case <-time.After(time.Until(deadline)):
+					// 当前 URL 超时按未命中算,与 r5 时刻处理一致。
+				}
+			}
+			t.Logf("%s  now=%d/%d  r5=%d/%d", fname, nowHit, len(group), r5Hit, len(group))
+		})
+	}
+}
+
+type badCaseRow struct {
+	YAMLFile string
+	Product  string
+	URL      string
+	R5Match  bool
+}
+
+func loadBadCaseURLs(path string) ([]badCaseRow, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []badCaseRow
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1<<16), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 4 {
+			continue
+		}
+		out = append(out, badCaseRow{
+			YAMLFile: fields[0],
+			Product:  fields[1],
+			URL:      fields[2],
+			R5Match:  strings.EqualFold(fields[3], "true"),
+		})
+	}
+	return out, sc.Err()
+}

--- a/convert/testdata/badcase_finger_r5_20260608/README.md
+++ b/convert/testdata/badcase_finger_r5_20260608/README.md
@@ -1,0 +1,52 @@
+# Bad-case 指纹用例集(r5 实跑回归基线,2026-06-08)
+
+## 这是什么
+
+2026-06-08 SDK v0.2.4 在 1655 个抓取目标上跑 `batch_compare`(r5 全量实跑),发现下面 22 件 xray 指纹 YAML 在转换 → 执行链路上漏检明显。这个目录把 **原始 xray YAML + r5 时刻每个产品的实测 URL 列表 + 当时 SDK 的命中结果** 一起入库,作为 converter/executer 改动的回归基线。
+
+## 文件清单
+
+```
+urls.tsv                              219 行,字段:yaml_file\tproduct\turl\tr5_sdk_match\tr5_sdk_fingerprints
+<product>.yaml                        21 件 xray 指纹 YAML,从 reports/focus-validate/xray_fingers.tgz 中拆出
+```
+
+YAML 文件是 **xray 格式**(`name: fingerprint-<vendor>--<product>` + `detail.fingerprint.name`),不是转换后的 nuclei 模板。`Convert(yaml) → templates.Template → tmpl.Execute(url)` 这条链在测试里现场跑。
+
+## r5 实测概要(命中数 / 目标数)
+
+| 文件 | 产品 | r5 实测 | 备注 |
+|---|---|---|---|
+| aisite.yaml | 中科汇联-AiSite | 0/20 | r5 全 0,根因疑似 dir() 或 favicon hash 规则丢失 |
+| weaver_e_office.yaml | 泛微-EOffice | 0/10 | redirects:false + contains(location,...) 漏检 |
+| weblogic.yaml | WebLogic-Server | 0/10 | version_in_header + AND→OR 转换器丢规则 |
+| sslvpn_4.yaml | Array-SSL-VPN | 0/10 | |
+| iam.yaml | 竹云-IAM | 0/10 | 末块超时丢已有 result |
+| goahead.yaml | Embedthis GoAhead | 0/10 | |
+| haiyun.yaml | 拓尔思-政府网站集约化 | 0/10 | |
+| empirecms.yaml | 帝国CMS | 8/10 | 已基本追平 debug |
+| wcm.yaml | 拓尔思-WCM | 6/10 | |
+| erds.yaml | 讯投-ERDS | 10/10 | r5 已经命中 |
+| 其它 | 详见 urls.tsv |  | |
+
+完整逐行命中明细在 `urls.tsv` 第 4 列(`True`/`False` = r5 当时 SDK 的 sdk_match)。
+
+## 怎么用
+
+`convert/badcase_finger_test.go` 里的 `TestBadCaseFinger_R5Targets` 会:
+1. 把 testdata 下所有 `*.yaml` 用 `Convert` 转换;
+2. 对每个 URL 跑一次 `tmpl.Execute(url)`;
+3. 输出当前命中率,和 `urls.tsv` 里的 r5 基线做对比。
+
+默认 `go test -short` 跳过网络部分,只验 Convert + Compile 不 panic。要复跑实测加 `-run BadCaseFinger -timeout 30m`。
+
+## 不在这里固化的事
+
+- 不固化"漏检的产品必须漏检"——这只是回归基线,不是期望。
+- 不锁定具体目标可达性——`urls.tsv` 里若干 URL 几个月后必然失活,失活按 r5 时刻数据为准,不影响测试通过。
+
+## 关联
+
+- [[project_finger_ci_yaml_followups_20260608]](memory)
+- [[project_sdk_v024_equivalence_and_finger_conversion_gap_20260608]](memory)
+- [[project_sdk_v024_finger_gap_redirects_false]](memory)

--- a/convert/testdata/badcase_finger_r5_20260608/actuator.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/actuator.yaml
@@ -1,0 +1,111 @@
+name: fingerprint-spring--actuator
+detail:
+  vendor: 144794ab-0ef7-434f-98ad-6499189d28de
+  product: 61eebc5f-eefe-4fe8-81f3-4c9deb456b86
+  fingerprint:
+    name: SpringBoot Actuator
+    cpe: spring:actuator
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+set:
+  404Path: get404Path()
+
+rules:
+
+  kw_in_index:
+    request:
+      cache: true
+      method: GET
+      path: /
+      follow_redirects: false
+      headers:
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+    expression: |-
+      response.body_string.contains("<h1>Whitelabel Error Page</h1>")
+      || (
+      response.body_string.contains("assets/js/vue.min.js")
+      && response.body_string.contains("assets/js/element.js")
+      )
+      || response.body_string.contains('"msg":"404 NOT_FOUND"')
+      || response.body_string.contains("Full authentication is required to access this resource")
+      || response.headers['content-type'].contains("application/json")
+
+  kw_in_404_body:
+    request:
+      cache: true
+      method: GET
+      path: /{{404Path}}
+      follow_redirects: false
+      headers:
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+    expression: |-
+      response.body_string.contains("<h1>Whitelabel Error Page</h1>")
+      || (
+      response.body_string.contains("assets/js/vue.min.js")
+      && response.body_string.contains("assets/js/element.js")
+      )
+      || response.body_string.contains('"msg":"404 NOT_FOUND"')
+      || response.body_string.contains("Full authentication is required to access this resource")
+      || response.headers['content-type'].contains("application/json")
+  kw_in_actuator:
+    request:
+      cache: true
+      method: GET
+      path: /actuator
+      follow_redirects: false
+    expression: |-
+      response.body_string.contains("/actuator")
+      && response.body_string.contains('"_links":{')
+      && (response.body_string.contains('"env":{') || response.headers['content-type'].contains("spring-boot.actuator"))
+
+  kw_in_health_body:
+    request:
+      cache: true
+      method: GET
+      path: /health
+      follow_redirects: false
+      headers:
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+    expression: |-
+      response.status == 200 &&
+      response.headers['content-type'].contains("spring-boot.actuator")
+      || ( response.body_string.startsWith('{"code":')
+      && response.body_string.contains('"status":')
+      && response.body_string.contains('"ping":')
+      )
+  kw_in_actuator_health_body:
+    request:
+      cache: true
+      method: GET
+      path: /actuator/health
+      follow_redirects: false
+      headers:
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+    expression: |-
+      response.status == 200 &&
+      response.headers['content-type'].contains("spring-boot.actuator")
+      || ( response.body_string.startsWith('{"code":')
+      && response.body_string.contains('"status":')
+      && response.body_string.contains('"ping":')
+      )
+      
+  favicon_hash:
+    request:
+      cache: true
+      method: GET
+      path: /
+      follow_redirects: false
+    expression: faviconHash(response.getIconContent()) == 116323821
+
+expression: |-
+    (
+    favicon_hash() || kw_in_index() || kw_in_404_body()
+    ) && (
+    kw_in_actuator()
+    || kw_in_actuator_health_body() 
+    || kw_in_health_body() 
+    )
+
+
+# http://218.95.166.97:8000/;/env/

--- a/convert/testdata/badcase_finger_r5_20260608/aisite.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/aisite.yaml
@@ -1,0 +1,51 @@
+name: fingerprint-huilan--aisite
+detail:
+  vendor: b55bd297-c587-4851-ab1b-6e120420a0aa
+  product: 2514ed12-e748-4c3e-a233-7c53ac6aa0af
+  fingerprint:
+    name: 中科汇联-AiSite
+    cpe: huilan:aisite
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+set:
+  n1: randomLowercase(4)
+
+rules:  
+  kw_in_body:
+    request:
+      path: /
+      cache: true
+      method: GET
+      follow_redirects: true
+    expression: |-
+      response.body_string.icontains('eprotalCurrent')
+  
+  kw_in_eportal:
+    request:
+      path: /eportal/ui?pageId=1
+      cache: true
+      method: GET
+      follow_redirects: true
+    expression: |-
+      response.body_string.icontains('easysite_msg_tip_div') || response.body_string.contains('easysite-error') || response.body_string.contains('此频道不存在')
+
+  kw_in_body_keyword:
+    request:
+      path: /
+      cache: true
+      method: GET
+      follow_redirects: true
+    expression: |-
+      response.body_string.icontains('aisitetheme')
+
+  kw_in_portal_url:
+    request:
+      path: /eportal/ui?portal.url={{n1}}
+      cache: true
+      method: GET
+      follow_redirects: true
+    expression: |-
+      response.body_string.contains('格式非法禁止访问') && response.body_string.contains('portal.url')
+
+expression: (kw_in_body() || kw_in_eportal()) && (kw_in_body_keyword() || kw_in_portal_url())

--- a/convert/testdata/badcase_finger_r5_20260608/empirecms.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/empirecms.yaml
@@ -1,0 +1,38 @@
+name: fingerprint-empiresoft--empirecms
+detail:
+  vendor: a64063fe-62aa-4170-94d7-630d5350bbfe
+  product: 075e6881-faa2-492c-b696-4b848918c3cb
+  fingerprint:
+    name: 帝国CMS
+    cpe: empiresoft:empirecms
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  index_contains:
+    expression: response.title_string.contains('EmpireCMS') ||
+                response.body_string.contains('EmpireCMS</a></strong>')
+  get_version:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: response.status == 200 && response.body_string.contains("EmpireCMS</a></strong>") && response.body_string.contains("</font></strong>&nbsp; &copy;")
+    output:
+      search: |
+        r'">(?P<version>.+?)</font></strong>&nbsp; &copy;'.submatch(response.body_string)
+      version: search['version']
+  get_version2:
+    request:
+      method: GET
+      path: /e/admin/adminstyle/1/page/about.htm
+    expression: response.status == 200 && response.body_string.contains("&nbsp;Version ")
+    output:
+      search: |
+        r'nbsp;Version (?P<version>.+?)</font>'.submatch(response.body_string)
+      version: search['version']
+expression: index_contains() && (get_version() || get_version2() || true)
+
+# Fofa Query
+# app="帝国软件-EmpireCMS"

--- a/convert/testdata/badcase_finger_r5_20260608/erds.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/erds.yaml
@@ -1,0 +1,33 @@
+name: fingerprint-thinktrader--erds
+detail:
+  vendor: ee169a72-d89d-4907-8bb2-890a801aaa9b
+  product: ef80fbc9-5494-4695-8ae7-97b2229eeb73
+  fingerprint:
+    name: 讯投-ERDS
+    cpe: thinktrader:erds
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  kw_in_body:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.contains("<p>4.成功登陆ERDS系统。</p>")
+expression: kw_in_body()
+
+# FOFA QUERY
+# body="<p>4.成功登陆ERDS系统。</p>"
+# https://114.245.241.82:8088/
+# http://175.25.41.229:9001/
+# https://qmt-level2.ciccwm.com/
+# http://175.25.41.71:9001/
+# https://175.25.41.71:8088/
+# https://175.25.41.229:8000/
+# https://175.25.41.221:8812/
+# https://210.14.143.251:8853/
+# https://175.25.41.217:8088/
+# https://175.25.41.251:8855/

--- a/convert/testdata/badcase_finger_r5_20260608/ezoffice.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/ezoffice.yaml
@@ -1,0 +1,31 @@
+name: fingerprint-wanhusoft--ezoffice
+detail:
+  vendor: 477674ab-9fed-4276-9d32-cca15e093053
+  product: 3629efbd-1fa8-4313-b6e4-9800c46a1bbb
+  fingerprint:
+    name: 万户-OA
+    cpe: wanhusoft:ezoffice
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  kw_in_body_00:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      (response.body_string.contains('defaultroot/themes') && response.body_string.contains("defaultroot/scripts")) ||
+      (response.headers['Set-Cookie'].contains('OASESSIONID') && response.body_string.contains('defaultroot'))
+
+  kw_in_body_01:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains('window.location') && response.body_string.contains('/defaultroot/login.jsp')
+expression: kw_in_body_00() || kw_in_body_01()
+
+# FOFA QUERY
+# app="万户网络-ezOFFICE"
+# http://oa.cctaa.cn/

--- a/convert/testdata/badcase_finger_r5_20260608/facial_love_cloud_platform.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/facial_love_cloud_platform.yaml
@@ -1,0 +1,30 @@
+name: fingerprint-szjocat--facial_love_cloud_platform
+detail:
+  vendor: a395af0a-c174-4508-9ab0-4978757942c6
+  product: 7a3f7086-b9d5-464c-b031-305dcb3aeb4a
+  fingerprint:
+    name: 脸爱云一脸通智慧管理平台
+    cpe: szjocat:facial_love_cloud_platform
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  kw_in_body:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains("脸爱云")
+  kw_in_body1:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains("View/SystemMng/PwdChanges.aspx")
+  
+expression:  (kw_in_body() || kw_in_body1())
+
+# Fofa Query
+# body='View/UserReserved/UserReservedTest.aspx'
+# http://113.96.110.33:1000/

--- a/convert/testdata/badcase_finger_r5_20260608/geoserver.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/geoserver.yaml
@@ -1,0 +1,42 @@
+name: fingerprint-geoserver--geoserver
+detail:
+  vendor: 82f90937-b012-4914-b366-3737673c7f4e
+  product: ff1d4c5b-dcc1-4e55-af49-3e31536b1735
+  fingerprint:
+    name: GeoServer
+    cpe: geoserver:geoserver
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+payloads:
+  payloads:
+    web:
+      entry: r"/"
+    server:
+      entry: r"/geoserver/"
+
+rules:
+  kw_in_body:
+    request:
+      method: GET
+      path: "{{entry}}web/"
+    expression: |
+      response.body_string.contains('org.geoserver.web')
+    output:
+      # TODO: 兼容云图
+      path: entry
+  version_detect:
+    request:
+      method: GET
+      path: "{{entry}}web/"
+    expression: |
+      '<strong>(?P<version>[0-9\\.]+)'.matches(response.body_string)
+    output:
+      search: |
+        '<strong>(?P<version>[0-9\\.]+)'.submatch(response.body_string)
+      version: search['version']
+expression: kw_in_body() && (version_detect() || true)
+
+# Fofa Query
+# app="GeoServer"
+# http://82.76.36.89:30047/

--- a/convert/testdata/badcase_finger_r5_20260608/goahead.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/goahead.yaml
@@ -1,0 +1,18 @@
+name: fingerprint-embedthis--goahead
+detail:
+  vendor: f28ec7e6-62c7-4e0c-9897-04922ca64470
+  product: 13691e5c-73ed-40e8-8d3b-4b22734423d6
+  fingerprint:
+    name: Embedthis GoAhead
+    cpe: embedthis:goahead
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  kw_in_server:
+    request:
+      method: GET
+      path: /
+    expression: response.headers['server'].icontains('GoAhead')
+expression: kw_in_server()

--- a/convert/testdata/badcase_finger_r5_20260608/haiyun.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/haiyun.yaml
@@ -1,0 +1,23 @@
+name: fingerprint-trs--haiyun
+detail:
+  vendor: 8202a756-24a6-476c-aa74-1b6ead3618a1
+  product: 8778a35a-150e-428e-9752-55ed761c1f46
+  fingerprint:
+    name: 拓尔思-政府网站集约化
+    cpe: trs:haiyun
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  igi_contains:
+    request:
+      method: GET
+      path: /IGI/
+      follow_redirects: false
+    expression: |
+            response.raw_header.bcontains(b'/ids/LoginServlet')
+expression: igi_contains()
+
+# FOFA QUERY
+# https://www.hubei.gov.cn

--- a/convert/testdata/badcase_finger_r5_20260608/iam.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/iam.yaml
@@ -1,0 +1,37 @@
+name: fingerprint-bamboocloud--iam
+detail:
+  vendor: 303c8811-8dfc-40d7-9dad-f4caddb7490e
+  product: 68927fcc-43ca-4a78-bf94-77c2fd30e259
+  fingerprint:
+    name: 竹云-IAM
+    cpe: bamboocloud:iam
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  r0:
+    expression: response.body_string.contains('/idp/AuthnEngine')
+
+  kw_in_body:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains("./static/config.js")
+
+  kw_in_config:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /static/config.js
+    expression: |-
+      response.body_string.contains("idpUrl") && response.body_string.contains("authCenter")
+expression: r0() || ( kw_in_body() && kw_in_config() )
+
+# Fofa Query
+# body="/idp/AuthnEngine"
+# https://iam.hnchasing.com/

--- a/convert/testdata/badcase_finger_r5_20260608/igi.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/igi.yaml
@@ -1,0 +1,18 @@
+name: fingerprint-trs--igi
+detail:
+  vendor: 8202a756-24a6-476c-aa74-1b6ead3618a1
+  product: 703fe9eb-079a-435c-8170-54069edf717e
+  fingerprint:
+    name: 拓尔思-IGI
+    cpe: trs:igi
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  index_contains:
+    expression: response.body_string.contains('/IGI/nbhd')
+expression: index_contains()
+
+# FOFA QUERY
+# http://www.cqxs.gov.cn/

--- a/convert/testdata/badcase_finger_r5_20260608/springboot.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/springboot.yaml
@@ -1,0 +1,62 @@
+name: fingerprint-vmware--springboot
+detail:
+  vendor: de453d0e-be1e-4d4d-93ff-84804145dd9d
+  product: 4ac41fba-5f47-43c5-b7a0-31f4737047c8
+  fingerprint:
+    name: SpringBoot
+    cpe: vmware:springboot
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+set:
+  404Path: get404Path()
+
+rules:
+  kw_in_404_body:
+    request:
+      cache: true
+      method: GET
+      path: /{{404Path}}
+      headers:
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+    expression: response.body_string.contains("<h1>Whitelabel Error Page</h1>")
+  favicon_hash:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: md5(response.getIconContent()) == "0488faca4c19046b94d07c3ee83cf9d6" || faviconHash(response.getIconContent()) == 116323821
+  kw_in_cookie:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: "\"set-cookie\" in response.headers 
+&& response.headers[\"set-cookie\"].contains(\"org.springframework.web.servlet.i18n.CookieLocaleResolver\")"
+
+  kw_in_actuator:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: 
+      response.body_string.contains('/actuator/info') && response.body_string.contains('target="_blank">')
+
+  kw_in_eureka:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains('eureka/css/')
+      || response.body_string.contains('src="eureka/js/')
+
+  kw_in_eureka1:
+    request:
+      cache: true
+      method: GET
+      path: /eureka/css/wro.css
+    expression: response.body_string.contains('spring-logo-eureka')
+expression: |-
+  favicon_hash() || kw_in_404_body() || kw_in_cookie()
+  || kw_in_actuator() || (kw_in_eureka() && kw_in_eureka1())

--- a/convert/testdata/badcase_finger_r5_20260608/ssl_vpn.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/ssl_vpn.yaml
@@ -1,0 +1,46 @@
+name: fingerprint-qianxin--ssl_vpn
+detail:
+  vendor: 9b68d62b-c577-45d4-af14-0086eb7ae796
+  product: d4468d1e-14a9-468e-a5cb-eee589fc4b98
+  fingerprint:
+    name: 奇安信-SSLVPN
+    cpe: qianxin:ssl_vpn
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  basic0_7175:
+    expression: |-
+      response.body_string.contains("1=@@=本地认证=@@=1=@@=本地认证=@@=0=@@=0=@@=0=@@=0") ||
+      response.body_string.contains("<title>奇安信VPN") ||
+      (response.body_string.contains("请使用手机奇安信ID扫码登录") && response.body_string.contains("VPN"))
+      || response.body_string.contains('<a href="sslvpn://" target="_blank">启动MAC客户端登录</a>')
+  
+  kw_download_page:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.contains("client.href='itms-services://?action=download-manifest&url='")
+
+  kw_in_vpn_gateway:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: |- 
+      response.body_string.contains('网神VPN安全网关系统')
+      || (response.body_string.contains('var __httpsVerify') && response.body_string.contains("Public/resources/mPlugin/mToken.js"))
+  kw_in_cookies:
+      request:
+        method: GET
+        path: /
+      expression: response.headers['set-cookie'].contains('mod_pass_param=') && response.headers['set-cookie'].contains('portal_param=') && response.headers['set-cookie'].contains('client_style=')
+
+expression: basic0_7175() || kw_download_page() || kw_in_vpn_gateway() || kw_in_cookies()
+
+# FOFA QUERY
+# body="1=@@=本地认证=@@=1=@@=本地认证=@@=0=@@=0=@@=0=@@=0" || (body="var client = document.getElementById(\"ios_dropdown_client\")" && icon_hash="634255230")

--- a/convert/testdata/badcase_finger_r5_20260608/sslvpn_4.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/sslvpn_4.yaml
@@ -1,0 +1,19 @@
+name: fingerprint-arraynetworks--sslvpn
+detail:
+  vendor: 907f72f7-8f03-4dfa-982b-a799a7577452
+  product: 899aafaf-592e-4c5a-9578-88545d9e08a4
+  fingerprint:
+    name: Array-SSL-VPN
+    cpe: arraynetworks:sslvpn
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  r0:
+    expression: response.body_string.contains('/prx/000/http/')
+expression: r0()
+
+# Fofa Query
+# app="Array-VPN"
+# https://ysdceshi.jlpay.com:8081/

--- a/convert/testdata/badcase_finger_r5_20260608/tongweb.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/tongweb.yaml
@@ -1,0 +1,61 @@
+name: fingerprint-tongtech--tongweb
+detail:
+  vendor: 12ae734d-d3de-4fe1-8141-2bfbc1e0d363
+  product: 8c075dcf-6870-4b00-ad3d-97a0558a9b6a
+  fingerprint:
+    name: TongWeb-东方通应用服务器
+    cpe: tongtech:tongweb
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+set:
+  rStr3: randomLowercase(8)
+
+rules:
+  kw_in_header_without_dereict:
+    request:
+      cache: true
+      follow_redirects: false
+      method: GET
+      path: /
+    expression: response.headers["Server"].icontains("TongWeb Server")
+  kw_in_header:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.headers["Server"].icontains("TongWeb Server")
+  kw_in_header1:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.headers["Server"].icontains("webserver")
+  kw_in_body:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /console/
+    expression: |-
+      response.title_string == "TongWeb"
+      || (
+      response.body_string.contains("/console/rest/i18n?locale=")
+      && response.body_string.contains("/console/notinrealm/rest/commons")
+      )
+  ejb_ok:
+    request:
+      method: GET
+      path: /ejbserver/ejb
+    expression: |-
+      size(response.body_string) == 0 && response.status ==200 
+
+  ejb_not_ok:
+    request:
+      method: GET
+      path: /ejbserver/{{rStr3}}
+    expression: |-
+      response.status == 404
+expression: kw_in_header_without_dereict() || kw_in_header() || (kw_in_header1() &&  kw_in_body()) || (ejb_ok() && ejb_not_ok())

--- a/convert/testdata/badcase_finger_r5_20260608/urls.tsv
+++ b/convert/testdata/badcase_finger_r5_20260608/urls.tsv
@@ -1,0 +1,222 @@
+# 字段:yaml_file<TAB>product<TAB>url<TAB>r5_sdk_match<TAB>r5_sdk_fingerprints
+# 来源:reports/focus-validate/finger-compare-r5/sdk-out.json.shard{0,1}
+# 数据时间:2026-06-08;wufeng_product 是抓取源的标注,r5_sdk_match 是 v0.2.4 batch_compare 的实测
+aisite.yaml	中科汇联-AiSite	https://111.23.154.184/nxyx/sy2023/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://111.23.154.184/nxyx/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://58.20.91.124/nxyx/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://58.20.91.124/nxyx/sy2023/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://www.nxyqszx.cn/nxyx/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://111.23.154.184/nxyx/ztpd/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://111.23.154.184/nxyx/_nongxy915379933/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://58.20.91.124/nxyx/_nongxy915379933/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://58.20.91.124/nxyx/ztpd/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-AiSite	https://www.nxyqszx.cn/nxyx/ztpd/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://zjt.ln.gov.cn/zjt/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://slt.ln.gov.cn/slt/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://jgsw.ln.gov.cn/index/	False	
+aisite.yaml	中科汇联-aisite	http://yjgl.ln.gov.cn/yjgl/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://gzw.ln.gov.cn/gzw/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://zjt.ln.gov.cn/index/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://slt.ln.gov.cn/index/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://mzw.ln.gov.cn/mzw/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://jgsw.ln.gov.cn/jgsw/	False	easysite-内容管理平台,中科汇联-aisearch
+aisite.yaml	中科汇联-aisite	http://yjgl.ln.gov.cn/index/	False	easysite-内容管理平台,中科汇联-aisearch
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://113.230.75.34:6100/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://hanwang.haoyehuagong.com:6100/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/View/UserReserved/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/ASHXRequest/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/View/SystemMng/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://oa.haoyehuagong.com:6100/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/View/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/scripts/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/ASHXRequest/SystemIndex/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+facial_love_cloud_platform.yaml	脸爱云一脸通智慧管理平台	http://120.198.121.118:1000/UserSite/	True	脸爱云一脸通智慧管理平台,脸爱云一脸通智慧管理平台
+wordpress.yaml	WordPress	https://42.193.123.102/	True	wordpress
+wordpress.yaml	WordPress	https://8.148.213.166/	True	wordpress
+wordpress.yaml	WordPress	http://www.wangshifu.net/	False	
+wordpress.yaml	WordPress	https://www.uut8.com/	True	wordpress
+wordpress.yaml	WordPress	https://www.mxj-xb.online/	True	wordpress,wordpress
+wordpress.yaml	WordPress	http://42.193.123.102/	True	wordpress
+wordpress.yaml	WordPress	https://175.178.80.135/	True	wordpress,wordpress
+wordpress.yaml	WordPress	http://8.148.213.166/	True	wordpress
+wordpress.yaml	WordPress	https://www.wangshifu.net/	False	
+wordpress.yaml	WordPress	http://www.uut8.com/	True	wordpress
+tongweb.yaml	TongWeb-东方通应用服务器	https://118.213.241.130/	True	jeecms,springboot,tongweb-东方通应用服务器
+tongweb.yaml	TongWeb-东方通应用服务器	http://www.shputuo.jcy.gov.cn/	False	jeecms
+tongweb.yaml	TongWeb-东方通应用服务器	http://www.shminhang.jcy.gov.cn/	False	jeecms
+tongweb.yaml	TongWeb-东方通应用服务器	https://www.qh.jcy.cn/	True	jeecms,springboot,tongweb-东方通应用服务器
+tongweb.yaml	TongWeb-东方通应用服务器	http://221.7.197.159:8090/	True	tongweb-东方通应用服务器
+tongweb.yaml	TongWeb-东方通应用服务器	https://www.wasx.qh.jcy.gov.cn/	True	jeecms,springboot,tongweb-东方通应用服务器
+tongweb.yaml	TongWeb-东方通应用服务器	http://www.shpudong.jcy.gov.cn/	False	jeecms
+tongweb.yaml	TongWeb-东方通应用服务器	https://www.qh.jcy.gov.cn/	True	jeecms,springboot,tongweb-东方通应用服务器
+tongweb.yaml	TongWeb-东方通应用服务器	http://218.60.145.11:9060/console/	True	tongweb-东方通应用服务器
+tongweb.yaml	TongWeb-东方通应用服务器	http://219.232.86.56:8183/	True	tongweb-东方通应用服务器
+geoserver.yaml	GeoServer	http://big-data.gxota.com:8080/geoserver/	False	
+geoserver.yaml	GeoServer	http://gxlwlc.com:7006/geoserver/	True	geoserver
+geoserver.yaml	GeoServer	http://sjcj.zhpt.yjglt.gxzf.gov.cn:8040/geoserver/	False	
+geoserver.yaml	GeoServer	https://zh.gflc.cn:18080/geoserver/	True	geoserver
+geoserver.yaml	GeoServer	https://www.gfslgy.com:18080/geoserver/	True	geoserver
+geoserver.yaml	GeoServer	http://219.159.80.180:7006/geoserver/	True	geoserver
+geoserver.yaml	GeoServer	http://116.252.25.47:8040/geoserver/	False	
+geoserver.yaml	GeoServer	https://219.159.80.130:18080/geoserver/	True	geoserver
+geoserver.yaml	GeoServer	https://xctd.gflc.cn:18080/geoserver/	True	geoserver
+geoserver.yaml	GeoServer	https://gflc.cn:18080/geoserver/	True	geoserver
+ezoffice.yaml	万户-OA	https://oanew.gxmuyfy.cn/	False	
+ezoffice.yaml	万户-OA	http://wbb.czsrmyy.com:7001/	True	万户-oa
+ezoffice.yaml	万户-OA	http://jktj.czsrmyy.com:7001/	True	万户-oa
+ezoffice.yaml	万户-OA	http://113.140.33.16:29093/	True	万户-oa
+ezoffice.yaml	万户-OA	http://oa.glwyy.org.cn:7001/	True	万户-oa
+ezoffice.yaml	万户-OA	http://222.216.107.200:7001/	True	万户-oa
+ezoffice.yaml	万户-OA	http://tijian.czsrmyy.com:7001/	True	万户-oa
+ezoffice.yaml	万户-OA	http://113.140.33.16:29093/defaultroot/	True	万户-oa
+ezoffice.yaml	万户-OA	http://119.97.207.194:7001/	True	万户-oa
+weaver_e_office.yaml	泛微-EOffice	http://hcsfby.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://tjxt.hcsfby.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://oa.hcsfby.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://cjgtest.gljiatianxia.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://www.qzzyyy.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://222.218.124.28:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://weixin.hcsfby.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://tjwc.hcsfby.com:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://111.59.121.238:8010/	False	
+weaver_e_office.yaml	泛微-EOffice	http://116.9.163.83:8010/	False	
+yonyou_u8_oa.yaml	用友-OA	http://210.36.247.224:6901/	False	
+yonyou_u8_oa.yaml	用友-OA	http://202.199.32.60:8080/	False	apache axis,用友 grp-u8
+yonyou_u8_oa.yaml	用友-OA	http://cw.syu.edu.cn:8080/	False	apache axis,用友 grp-u8
+yonyou_u8_oa.yaml	用友-OA	http://47.108.25.40:8089/	True	用友-u8-cloud,用友-oa
+yonyou_u8_oa.yaml	用友-OA	http://yqss.51vj.net:8088/	True	用友-u8-cloud,用友-oa
+yonyou_u8_oa.yaml	用友-OA	http://cwcapp.ylu.cn:6901/	False	
+yonyou_u8_oa.yaml	用友-OA	http://caiwu.syu.edu.cn:8080/	False	apache axis,用友 grp-u8
+yonyou_u8_oa.yaml	用友-OA	http://183.215.22.206:8088/	True	用友-u8-cloud,用友-oa
+yonyou_u8_oa.yaml	用友-OA	http://121.40.95.47:8088/	True	用友-u8-cloud,用友-oa
+yonyou_u8_oa.yaml	用友-OA	https://193.226.247.99/	False	
+igi.yaml	拓尔思-IGI	http://sti.xizang.gov.cn/hdjl/ldxx/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	http://cx.guizhou.gov.cn/view/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	http://yjj.guizhou.gov.cn/gzcy/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	http://rfb.guizhou.gov.cn/gzcy/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	http://mzw.guizhou.gov.cn/hdjl/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	https://dsj.hainan.gov.cn/jysj/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	https://cx.guizhou.gov.cn/view/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	https://whhly.guizhou.gov.cn/hdjl/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	https://mzw.guizhou.gov.cn/hdjl/	True	拓尔思-igi
+igi.yaml	拓尔思-IGI	https://fgw.guizhou.gov.cn/hdjl/	True	拓尔思-igi
+weblogic.yaml	WebLogic-Server	http://zp.gxjsxy.cn/	False	
+weblogic.yaml	WebLogic-Server	http://presolvemaps.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://precbschicago.sso.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://preapi.pay.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://preaomenduchangmeinvheguanguoye.analytics.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://thoby.uat.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://preonestdv.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://prebet365aomen.vdi.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://prebaijialekaihuhuangguantouzhuwanfa.report.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+weblogic.yaml	WebLogic-Server	http://pre.somali.app.yuchai.com/sso/	False	oracle-oam,oracle-oam
+ssl_vpn.yaml	奇安信-SSLVPN	https://oa.bsdw.com.cn:4433/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://116.1.145.28:4430/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://oa.glwyy.org.cn:4430/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://shitang.zglzyc.com:64443/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://210.36.136.52/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://bkjr.bsnyjt.com:4433/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://wbb.glwyy.org.cn:4430/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://111.59.69.185:64443/	True	奇安信-sslvpn
+ssl_vpn.yaml	奇安信-SSLVPN	https://qyh.zglzyc.com:64443/	False	
+ssl_vpn.yaml	奇安信-SSLVPN	https://vpn.gxufe.edu.cn/	False	
+z-suite.yaml	永洪-BI	https://lqdm-scrm.dflzm.com/bi/	True	永洪-bi
+z-suite.yaml	永洪-BI	http://lqdm-scrm.dflzm.com/bi/	False	
+z-suite.yaml	永洪-BI	http://go.dflzm.com/bi/	False	
+z-suite.yaml	永洪-BI	https://xtbg.cptc56.com:9004/bi/	False	
+z-suite.yaml	永洪-BI	https://14.103.114.176/bi/	False	
+z-suite.yaml	永洪-BI	https://lqdm-scrm-uat.dflzm.com/bi/	True	永洪-bi
+z-suite.yaml	永洪-BI	http://lqdm-scrm-uat.dflzm.com/bi/	False	
+z-suite.yaml	永洪-BI	https://go.dflzm.com/bi/	True	永洪-bi
+z-suite.yaml	永洪-BI	https://114.255.212.50:9004/bi/	False	
+z-suite.yaml	永洪-BI	https://bi.cptc56.com:9004/bi/	False	
+empirecms.yaml	帝国CMS	http://www.gxwzgh.cn/search/	True	帝国cms
+empirecms.yaml	帝国CMS	http://www.haxuchang.jcy.gov.cn/search/	True	帝国cms
+empirecms.yaml	帝国CMS	http://www.wzhh120.com/search/	True	帝国cms
+empirecms.yaml	帝国CMS	http://36.138.164.218/mobile/news/	True	帝国cms
+empirecms.yaml	帝国CMS	https://www.bjsubway.com/mobile/news/	False	
+empirecms.yaml	帝国CMS	http://gxwzgh.cn/search/	True	帝国cms
+empirecms.yaml	帝国CMS	http://wzhh120.com/search/	True	帝国cms
+empirecms.yaml	帝国CMS	http://116.9.123.153/search/	True	帝国cms
+empirecms.yaml	帝国CMS	http://36.138.164.218/news/	True	帝国cms
+empirecms.yaml	帝国CMS	https://bjsubway.com/mobile/news/	False	
+wcm.yaml	拓尔思-WCM	http://hycloudtest.trscd.com.cn/gov/app/	False	
+wcm.yaml	拓尔思-WCM	http://hycloudtest.trscd.com.cn/gov/	False	
+wcm.yaml	拓尔思-WCM	http://xf.tmuyun.com/wcm/app/	True	拓尔思-wcm
+wcm.yaml	拓尔思-WCM	https://xf.tmuyun.com/wcm/	True	拓尔思-wcm
+wcm.yaml	拓尔思-WCM	http://qlzj.tmuyun.com/wcm/	True	拓尔思-wcm
+wcm.yaml	拓尔思-WCM	https://hycloudtest.trscd.com.cn/gov/app/	False	
+wcm.yaml	拓尔思-WCM	https://hycloudtest.trscd.com.cn/gov/	False	
+wcm.yaml	拓尔思-WCM	http://xf.tmuyun.com/wcm/	True	拓尔思-wcm
+wcm.yaml	拓尔思-WCM	https://xf.tmuyun.com/wcm/app/	True	拓尔思-wcm
+wcm.yaml	拓尔思-WCM	https://i.tmuyun.com/wcm/	True	拓尔思-wcm
+erds.yaml	讯投-ERDS	https://xuntou.net:8688/api/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://119.147.202.16:7007/dict/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://101.200.85.37:8688/api/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://dict.thinktrader.net/api/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	http://119.147.202.20/api/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://xuntou.net:7007/dict/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://101.200.85.37:7007/dict/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://218.16.123.137:7007/dict/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://218.16.123.137:8688/api/login/	True	讯投-erds
+erds.yaml	讯投-ERDS	https://code.xuntou.net/api/login/	True	讯投-erds
+sslvpn_4.yaml	Array-SSL-VPN	https://121.36.107.210/prx/000/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://rtc-stream-demo.meeting.shine.com.cn/prx/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://220.249.41.23/prx/000/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://ssh.hljgd.net/prod-api/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://ssh.hljgd.net/register/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://121.36.107.210/prx/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://rtc-stream-demo.meeting.shine.com.cn/prx/000/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://220.249.41.23:9443/prx/000/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://avpn.unicompayment.com/prx/000/	False	
+sslvpn_4.yaml	Array-SSL-VPN	https://ssh.hljgd.net/docs/	False	
+iam.yaml	竹云-IAM	http://cmp.cctv.com/apis/	False	
+iam.yaml	竹云-IAM	https://101.129.23.55/portal/	False	
+iam.yaml	竹云-IAM	http://cms-auth.cctvnews.cctv.com/login/	False	
+iam.yaml	竹云-IAM	http://101.129.23.74/	False	
+iam.yaml	竹云-IAM	https://pan.cctv.cn/	False	
+iam.yaml	竹云-IAM	https://cmp.cctv.cn/portal/	False	
+iam.yaml	竹云-IAM	https://cmp.cctv.cn/api/	False	
+iam.yaml	竹云-IAM	https://101.129.23.55/api/	False	
+iam.yaml	竹云-IAM	http://cmp.cctv.com/portal/	False	
+iam.yaml	竹云-IAM	https://101.129.23.74/	False	
+goahead.yaml	Embedthis GoAhead	https://42.180.254.142:40443/	False	
+goahead.yaml	Embedthis GoAhead	https://50.234.151.72/help/En/	False	
+goahead.yaml	Embedthis GoAhead	https://12.7.30.110/help/	False	
+goahead.yaml	Embedthis GoAhead	https://204.133.175.230/help/	False	
+goahead.yaml	Embedthis GoAhead	https://128.92.162.180/help/	False	
+goahead.yaml	Embedthis GoAhead	http://42.180.254.142:40080/	False	
+goahead.yaml	Embedthis GoAhead	https://12.153.246.86/help/En/	False	
+goahead.yaml	Embedthis GoAhead	https://12.155.60.9/help/En/	False	
+goahead.yaml	Embedthis GoAhead	https://24.153.202.13/help/	False	
+goahead.yaml	Embedthis GoAhead	https://12.148.90.238/help/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://zwgk.guizhou.gov.cn/IGI/nbhd/register/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://jkj.guizhou.gov.cn/IGI/nbhd/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://whhly.guizhou.gov.cn/IGI/nbhd/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://wsg.guizhou.gov.cn/IGI/opinion/	False	
+haiyun.yaml	拓尔思-政府网站集约化	http://jyglj.guizhou.gov.cn/IGI/nbhd/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://zwgk.guizhou.gov.cn/IGI/nbhd/solr/	False	
+haiyun.yaml	拓尔思-政府网站集约化	http://yjj.guizhou.gov.cn/IGI/nbhd/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://nyj.guizhou.gov.cn/IGI/nbhd/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://wsg.guizhou.gov.cn/IGI/nbhd/	False	
+haiyun.yaml	拓尔思-政府网站集约化	https://jr.guizhou.gov.cn/IGI/nbhd/	False	
+springboot.yaml	SpringBoot	https://110.72.47.44:8000/view/	False	
+springboot.yaml	SpringBoot	https://222.84.136.178:24001/portal/	True	springboot,springboot actuator
+springboot.yaml	SpringBoot	http://www.glzyjn.com/gateway/	True	springboot actuator
+springboot.yaml	SpringBoot	http://221.7.197.180:8060/api/	False	
+springboot.yaml	SpringBoot	https://plat.sgmwsales.com/plat/	False	
+springboot.yaml	SpringBoot	https://222.84.136.178/portal/	False	
+springboot.yaml	SpringBoot	https://www.glzyjn.com/gateway/	True	springboot,springboot actuator
+springboot.yaml	SpringBoot	http://wstzfw.swt.gxzf.gov.cn:8060/api/	False	
+springboot.yaml	SpringBoot	http://219.159.80.134:9000/app/	False	
+springboot.yaml	SpringBoot	https://219.159.80.134:9443/app/	True	springboot
+actuator.yaml	SpringBoot Actuator	http://apollo.miaowatech.cn:8083/	True	springboot,springboot actuator
+actuator.yaml	SpringBoot Actuator	http://jpom.miaowatech.cn:8180/	False	
+actuator.yaml	SpringBoot Actuator	http://mq.miaowatech.cn:8082/	True	springboot,springboot actuator
+actuator.yaml	SpringBoot Actuator	http://apollo.miaowatech.cn:8082/	True	springboot,springboot actuator
+actuator.yaml	SpringBoot Actuator	http://claw.gp88.top:3048/	True	springboot actuator
+actuator.yaml	SpringBoot Actuator	http://jpom.miaowatech.cn:8083/	True	springboot,springboot actuator
+actuator.yaml	SpringBoot Actuator	http://apollo.miaowatech.cn:8180/	False	
+actuator.yaml	SpringBoot Actuator	http://xjob.miaowatech.cn:8082/	True	springboot,springboot actuator
+actuator.yaml	SpringBoot Actuator	http://jpom.miaowatech.cn:8082/	True	springboot,springboot actuator
+actuator.yaml	SpringBoot Actuator	http://117.72.28.68:8083/	True	springboot,springboot actuator

--- a/convert/testdata/badcase_finger_r5_20260608/wcm.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/wcm.yaml
@@ -1,0 +1,31 @@
+name: fingerprint-trs--wcm
+detail:
+  vendor: 8202a756-24a6-476c-aa74-1b6ead3618a1
+  product: 81cb92ce-0af5-463f-9a90-c953e7c9a276
+  fingerprint:
+    name: 拓尔思-WCM
+    cpe: trs:wcm
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  index_contains:
+    expression: response.body_string.contains('WCMAnt:param=') ||
+                response.body_string.contains('URL=/wcm') ||
+                response.body_string.icontains('window.location.href = /wcm;') ||
+                response.raw_header.ibcontains(b"com.trs.idm.coSessionId")
+  version_detect:
+    request:
+      method: GET
+      path: /wcm/app/js/source/wcmlib/WCMConstants.js
+    expression: true
+    output:
+      search: |
+          "WCM v(?P<version>[0-9\\.]+)'".submatch(response.body_string)
+      version: search['version']
+expression: index_contains() && version_detect()
+
+# FOFA QUERY
+# app="拓尔思-WCM"
+# http://27.17.40.76/

--- a/convert/testdata/badcase_finger_r5_20260608/weaver_e_office.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/weaver_e_office.yaml
@@ -1,0 +1,52 @@
+name: fingerprint-weaver--weaver_e_office
+detail:
+  vendor: cc897b2c-6849-4975-a405-9c1ec3659f32
+  product: 820c16ef-5084-47cf-a1ba-d201bfa79631
+  fingerprint:
+    name: 泛微-EOffice
+    cpe: weaver:weaver_e_office
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  r1:
+    request:
+      cache: true
+      follow_redirects: false
+      method: GET
+      path: /
+    expression: |-
+      (
+      response.headers["Location"].contains("/general/login/index.php")
+      || response.body_string.contains('redirectUrl = "login.php"')
+      )
+      && response.body_string.contains('window.opener="eoffice";')
+  r2:
+    request:
+      cache: true
+      follow_redirects: false
+      method: GET
+      path: /
+    expression: response.headers["location"].contains("/eoffice10/client/web/login")
+
+
+  r3:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: 
+      response.body_string.contains("/eoffice10/client/web/")  && response.body_string.contains("eoffice_loading_tip")
+      || ( 
+      response.body_string.contains("clsid:FB4EE423-43A4-4AA9-BDE9-4335A6D3C74E")
+      && response.body_string.contains("/general/login/index.php?c=Login&a=updateSystem")
+      )
+
+
+expression: r1() || r2() || r3() 
+
+# FOFA QUERY
+# app="泛微-EOffice"
+# /eoffice10/client/web/ 是e-office10
+# /general/login/index.php 是e-office9

--- a/convert/testdata/badcase_finger_r5_20260608/weblogic.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/weblogic.yaml
@@ -1,0 +1,48 @@
+name: fingerprint-oracle--weblogic
+detail:
+  vendor: d9fb7791-36cd-4672-8c42-c086b2e09e50
+  product: d5d65242-0f32-4b41-8d9d-3ca1f4c7979c
+  fingerprint:
+    name: WebLogic-Server
+    cpe: oracle:weblogic
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+set:
+  pathname: get404Path()
+
+rules:
+  index_contains:
+    expression: response.headers['Server'].contains('WebLogic')
+                || response.status == 200 && response.body_string.contains("/console/framework/skins/wlsconsole/images/Branding_Login_WeblogicConsole.gif")
+                || response.body_string.contains('Welcome to Weblogic Application Server')
+                || response.body_string.contains("The server has not found anything matching the Request-URI. No indication is given of whether the condition is temporary or permanent.")
+
+  kw_in_404_body:
+    request:
+      method: GET
+      path: /{{pathname}}
+    expression: response.body_string.contains("The server has not found anything matching the Request-URI. No indication is given of whether the condition is temporary or permanent.")
+
+  version:
+    request:
+      method: GET
+      path: /console/login/LoginForm.jsp
+    expression: response.body_string.contains("WebLogic Server")
+    output:
+      search: |-
+        r"WebLogic Server (.*?: )?(?P<version>\d+\.\d+\.\d+\.\d+(\.\d+)?)".submatch(response.body_string)
+      version: search["version"]
+
+  version_in_header:
+    expression: response.headers['Server'].contains("WebLogic Server")
+    output:
+      search: |-
+        r"WebLogic Server (.*?: )?(?P<version>\d+\.\d+\.\d+\.\d+(\.\d+)?)".submatch(response.headers['Server'])
+      version: search["version"]
+
+expression: (index_contains() || kw_in_404_body()) && (version_in_header() || version() || true)
+
+# Fofa Query
+# app="BEA-WebLogic-Server"
+# http://129.213.197.42:8000/

--- a/convert/testdata/badcase_finger_r5_20260608/wordpress.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/wordpress.yaml
@@ -1,0 +1,34 @@
+name: fingerprint-wordpress--wordpress
+detail:
+  vendor: 4a1afb24-8a6b-4347-b0fd-5ecca0bdadda
+  product: 7ac878f2-59a0-4e75-98b6-a94a73ac7d0c
+  fingerprint:
+    name: WordPress
+    cpe: wordpress:wordpress
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  default_body_contains:
+    expression: (
+                response.body_string.contains('/wp-content/') ||
+                response.body_string.contains('content="WordPress')
+                )
+                && (response.body_string.contains("/wp-includes/js") ||
+                (response.body_string.contains('id="__next">') && !response.body_string.contains('href="/_next/')) || (response.body_string.contains('id="__next"') && response.body_string.contains('/wp-json/'))
+                )
+                
+
+
+  favicon_hash:
+    request:
+      method: GET
+      path: /
+    expression: faviconHash(response.getIconContent()) == 1198047028
+
+expression: (default_body_contains()|| favicon_hash()) 
+
+#尽力降低下面条件导致的误报，当response.body_string.contains('/wp-content/')与response.body_string.contains('id="__next"')同时满足条件
+#误报fofa： body="wp-content/" && body='id="__next"' && product!="AUTOMATTIC-WordPress"
+#

--- a/convert/testdata/badcase_finger_r5_20260608/yonyou_u8_oa.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/yonyou_u8_oa.yaml
@@ -1,0 +1,88 @@
+name: fingerprint-yonyou--yonyou_u8_oa
+detail:
+  vendor: 72c31530-a847-40bc-be70-8753373ce523
+  product: 679bd016-4ef6-4949-a850-c6e08778c25d
+  fingerprint:
+    name: 用友-OA
+    cpe: yonyou:yonyou_u8_oa
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  basic0_6976:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: "response.title_string.icontains(\"\u7528\u53CBGRP-U8 \u9AD8\u6821\
+      \u5185\u63A7\u7BA1\u7406\u8F6F\u4EF6\")"
+  basic10_3736:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: "response.title_string.icontains(\"\u7528\u53CBgrp-u8\")"
+  basic1_6975:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.icontains("logo/images/ufida_")
+  basic2_6974:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.icontains("/ext-js/images/usg")
+  basic3_3767:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: '"(?i)window.location.replace(\"login.jsp?up=1\")".matches(response.body_string)'
+  basic4_3765:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.icontains("javascript/bw8.js")
+  basic5_3764:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.icontains("var servervendor = 'yonyouupcn")
+  basic6_3763:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: "response.body_string.icontains(\"\u5F00\u542Fu8 cloud\u4E91\u7AEF\
+      \u4E4B\u65C5\")"
+  basic8_3761:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: "response.body_string.icontains(\"\u7528\u53CBGRP-U8\u884C\u653F\u4E8B\
+      \u4E1A\u5185\u63A7\u7BA1\u7406\u8F6F\u4EF6\")"
+  basic9_3748:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: response.body_string.icontains("getFirstU8Accid")
+expression: (basic0_6976()) || (basic1_6975()) || (basic2_6974()) || (basic3_3767())
+  || (basic4_3765()) || (basic5_3764()) || (basic6_3763()) || (basic8_3761())
+  || (basic9_3748()) || (basic10_3736())

--- a/convert/testdata/badcase_finger_r5_20260608/z-suite.yaml
+++ b/convert/testdata/badcase_finger_r5_20260608/z-suite.yaml
@@ -1,0 +1,69 @@
+name: fingerprint-yonghongtech--z-suite
+detail:
+  vendor: c9f14b8e-4402-49ea-aed1-7d832f98acd8
+  product: 60ea6420-f4af-4bc5-a943-3957e2b4db8f
+  fingerprint:
+    name: 永洪-BI
+    cpe: yonghongtech:z-suite
+    version: '{{version}}'
+  path: '{{path}}'
+transport: http
+
+rules:
+  kw_in_body:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains("/bi/?proc=2&action=loadFavicon")
+      && response.body_string.contains("/bi/?proc=2&locale=")
+
+  index_contains:
+    request:
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.icontains('yonghong') 
+      && (response.body_string.icontains('contentdiv imgposition desw')
+      || response.body_string.icontains('YH_CONFIG')
+      )
+
+  kw_in_body1:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /
+    expression: |-
+      response.body_string.contains("background:url(404.jpg)")
+
+  kw_in_body2:
+    request:
+      cache: true
+      follow_redirects: true
+      method: GET
+      path: /404.jpg
+    expression: |-
+      md5(response.body) == '77154f3efafe5b68423507a6658a636a'
+
+  favicon_hash:
+    request:
+      cache: true
+      method: GET
+      path: /
+    expression: faviconHash(response.getIconContent()) == 398162124
+
+  kw_in_proc:
+    request:
+      method: GET
+      path: /bi/?proc=1
+    expression: |-
+      response.body_string.icontains('yonghong') 
+      && (response.body_string.icontains('contentdiv imgposition desw')
+      || response.body_string.icontains('YH_CONFIG')
+      )
+
+      
+expression: kw_in_body() || index_contains() || (kw_in_body1() && kw_in_body2()) || favicon_hash() || kw_in_proc()

--- a/protocols/http/request.go
+++ b/protocols/http/request.go
@@ -23,6 +23,7 @@ import (
 )
 
 var errStopExecution = errors.New("stop execution due to unresolved variables")
+
 var _ protocols.Request = &Request{}
 
 type Request struct {
@@ -422,11 +423,22 @@ func (r *Request) executeRequest(input *protocols.ScanContext, request *generate
 	}
 
 	timeStart := time.Now()
-	// Per-execution client override (ScanContext.Client) takes precedence over the
-	// shared compiled client, so callers never mutate the shared template at runtime.
+	// Per-execution overrides: Transport takes precedence over Client.
+	// Transport-only override shallow-clones r.httpClient so CheckRedirect, Jar,
+	// and Timeout from the template's Compile() are preserved — only the
+	// RoundTripper is swapped (e.g. for active-match caching transports).
+	// Client override remains for back-compat but replaces the whole client
+	// (drops redirect policy) — see ScanContext docs.
 	client := r.httpClient
-	if input != nil && input.Client != nil {
-		client = input.Client
+	if input != nil {
+		switch {
+		case input.Transport != nil:
+			c := *r.httpClient
+			c.Transport = input.Transport
+			client = &c
+		case input.Client != nil:
+			client = input.Client
+		}
 	}
 	resp, err := client.Do(request.request)
 	common.Debug("request %s %v %v", request.request.Method, request.request.URL, request.dynamicValues)

--- a/protocols/http/tls_fields.go
+++ b/protocols/http/tls_fields.go
@@ -3,16 +3,51 @@
 
 package http
 
-import "net/http"
+import (
+	"crypto/x509"
+	"net/http"
+	"strings"
 
+	"github.com/chainreactors/neutron/common"
+)
+
+// certExtractors maps a neutron data-map key to a function that derives its
+// string value from the leaf certificate. Keys must stay in sync with the
+// values of common.XrayCertFields (asserted by TestCertFieldRegistryParity).
+var certExtractors = map[string]func(*x509.Certificate) string{
+	"cert_subject":      func(c *x509.Certificate) string { return c.Subject.String() },
+	"cert_issuer":       func(c *x509.Certificate) string { return c.Issuer.String() },
+	"cert_not_before":   func(c *x509.Certificate) string { return c.NotBefore.Format("2006-01-02 03:04:05") },
+	"cert_not_after":    func(c *x509.Certificate) string { return c.NotAfter.Format("2006-01-02 03:04:05") },
+	"cert_dnsnames":     func(c *x509.Certificate) string { return strings.Join(c.DNSNames, " ") },
+	"cert_serial":       func(c *x509.Certificate) string { return c.SerialNumber.String() },
+	"cert_common_name":  func(c *x509.Certificate) string { return c.Subject.CommonName },
+	"cert_organization": func(c *x509.Certificate) string { return strings.Join(c.Subject.Organization, " ") },
+}
+
+// addTLSCertFields fills certificate-derived keys into the response data map so
+// that DSL matchers converted from xray's response.cert.* / response.raw_cert
+// can be evaluated natively. Only the standard library is used.
 func addTLSCertFields(data map[string]interface{}, resp *http.Response) {
 	if resp == nil || resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
 		return
 	}
 
-	cert := resp.TLS.PeerCertificates[0]
-	data["cert_subject"] = cert.Subject.String()
-	data["cert_issuer"] = cert.Issuer.String()
-	data["cert_not_before"] = cert.NotBefore.Format("2006-01-02 03:04:05")
-	data["cert_not_after"] = cert.NotAfter.Format("2006-01-02 03:04:05")
+	leaf := resp.TLS.PeerCertificates[0]
+	for key, extract := range certExtractors {
+		if v := extract(leaf); v != "" {
+			data[key] = v
+		}
+	}
+
+	// raw_cert: concatenate the DER bytes of the whole presented chain. This
+	// mirrors xray's bcontains-over-DER semantics — organization/CN strings are
+	// stored as literal ASCII inside the DER encoding.
+	var raw strings.Builder
+	for _, cert := range resp.TLS.PeerCertificates {
+		raw.Write(cert.Raw)
+	}
+	if raw.Len() > 0 {
+		data[common.RawCertKey] = raw.String()
+	}
 }

--- a/protocols/http/tls_fields_test.go
+++ b/protocols/http/tls_fields_test.go
@@ -1,0 +1,33 @@
+//go:build !tinygo
+// +build !tinygo
+
+package http
+
+import (
+	"testing"
+
+	"github.com/chainreactors/neutron/common"
+)
+
+// TestCertFieldRegistryParity guards the single-source-of-truth invariant:
+// every cert data key declared in common.XrayCertFields must have a matching
+// extractor here, and vice versa. This prevents the converter and the runtime
+// from drifting apart when a cert field is added.
+func TestCertFieldRegistryParity(t *testing.T) {
+	// Every xray-mapped key must have an extractor.
+	for sub, key := range common.XrayCertFields {
+		if _, ok := certExtractors[key]; !ok {
+			t.Errorf("XrayCertFields[%q] -> %q has no extractor in certExtractors", sub, key)
+		}
+	}
+	// Every extractor must be referenced by at least one xray field.
+	referenced := make(map[string]bool, len(common.XrayCertFields))
+	for _, key := range common.XrayCertFields {
+		referenced[key] = true
+	}
+	for key := range certExtractors {
+		if !referenced[key] {
+			t.Errorf("certExtractors[%q] is not referenced by any XrayCertFields entry", key)
+		}
+	}
+}

--- a/protocols/scan.go
+++ b/protocols/scan.go
@@ -13,10 +13,23 @@ type ScanContext struct {
 	// exported / configurable fields
 	Input    string
 	Payloads map[string]interface{}
+	// Transport, when non-nil, overrides the per-request HTTP transport for this
+	// execution only. The request's compiled http.Client (CheckRedirect, Jar,
+	// Timeout, ...) is preserved via a shallow clone; only the RoundTripper is
+	// swapped. Active-match engines should prefer this over Client — replacing
+	// the whole client drops the template's `redirects:` policy and silently
+	// turns `redirects: false` templates into follow-302 templates.
+	Transport http.RoundTripper
 	// Client, when non-nil, overrides the per-request default HTTP client for
 	// this execution only. It lets active-match engines inject a client/transport
 	// without mutating the shared, compiled template (which is concurrency-unsafe).
 	// nil = use the request's own compiled client.
+	//
+	// Deprecated: prefer Transport. Setting Client wholesale replaces the
+	// compiled http.Client and discards CheckRedirect/Jar/Timeout — templates
+	// with `redirects: false` then silently follow 302s and lose Location-header
+	// matches. Retained only for backward compatibility; Transport takes
+	// precedence when both are set.
 	Client *http.Client
 	// callbacks or hooks
 	OnError  func(error)

--- a/protocols/ssl/request.go
+++ b/protocols/ssl/request.go
@@ -1,0 +1,530 @@
+package ssl
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/chainreactors/neutron/common"
+	"github.com/chainreactors/neutron/operators"
+	"github.com/chainreactors/neutron/protocols"
+)
+
+var _ protocols.Request = &Request{}
+
+// Type returns the type of the protocol request.
+func (r *Request) Type() protocols.ProtocolType {
+	return protocols.SSLProtocol
+}
+
+func (r *Request) getMatchPart(part string, data protocols.InternalEvent) (string, bool) {
+	switch part {
+	case "", "body", "all":
+		part = "response"
+	}
+	item, ok := data[part]
+	if !ok {
+		return "", false
+	}
+	return common.ToString(item), true
+}
+
+// Match matches a generic data response against a given matcher.
+func (r *Request) Match(data map[string]interface{}, matcher *operators.Matcher) (bool, []string) {
+	if matcher.GetType() == operators.DSLMatcher {
+		return matcher.Result(matcher.MatchDSL(data)), nil
+	}
+	itemStr, ok := r.getMatchPart(matcher.Part, data)
+	if !ok {
+		return false, []string{}
+	}
+	switch matcher.GetType() {
+	case operators.SizeMatcher:
+		return matcher.Result(matcher.MatchSize(len(itemStr))), []string{}
+	case operators.WordsMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchWords(itemStr, data))
+	case operators.RegexMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchRegex(itemStr))
+	case operators.BinaryMatcher:
+		return matcher.ResultWithMatchedSnippet(matcher.MatchBinary(itemStr))
+	}
+	return false, []string{}
+}
+
+// Extract performs an extracting operation for an extractor on data.
+func (r *Request) Extract(data map[string]interface{}, extractor *operators.Extractor) map[string]struct{} {
+	item, ok := r.getMatchPart(extractor.Part, data)
+	if !ok && extractor.GetType() != operators.DSLExtractor {
+		return nil
+	}
+	switch extractor.GetType() {
+	case operators.RegexExtractor:
+		return extractor.ExtractRegex(item)
+	case operators.KValExtractor:
+		return extractor.ExtractKval(data)
+	case operators.DSLExtractor:
+		return extractor.ExtractDSL(data)
+	}
+	return nil
+}
+
+// ExecuteWithResults connects to each target, performs the TLS handshake and
+// runs the operators against the certificate data.
+func (r *Request) ExecuteWithResults(input *protocols.ScanContext, dynamicValues, previous map[string]interface{}, callback protocols.OutputEventCallback) error {
+	var globalVars map[string]interface{}
+	var scanInput string
+	if input != nil {
+		globalVars = input.GlobalVars
+		scanInput = input.Input
+	}
+
+	target := r.resolveTarget(scanInput, common.MergeMaps(globalVars, dynamicValues))
+	return r.executeTarget(input, target, dynamicValues, previous, callback)
+}
+
+func (r *Request) resolveTarget(input string, vars map[string]interface{}) string {
+	host, port := splitHostPort(input)
+	hostname := host
+	if host != "" && port != "" {
+		hostname = net.JoinHostPort(host, port)
+	}
+	targetVars := map[string]interface{}{
+		"Host":     host,
+		"Hostname": hostname,
+		"Port":     port,
+		"BaseURL":  input,
+		"RootURL":  hostname,
+	}
+	merged := common.MergeMaps(vars, targetVars)
+
+	address := strings.TrimSpace(r.Address)
+	if address == "" {
+		return normalizeTarget(input)
+	}
+	resolved := common.Replace(address, merged)
+	return normalizeTarget(resolved)
+}
+
+func (r *Request) executeTarget(input *protocols.ScanContext, target string, dynamicValues, previous map[string]interface{}, callback protocols.OutputEventCallback) error {
+	host, _ := splitHostPort(target)
+
+	cfg := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         host,
+	}
+	if v := tlsVersionValue(r.MinVersion); v != 0 {
+		cfg.MinVersion = v
+	}
+	if v := tlsVersionValue(r.MaxVersion); v != 0 {
+		cfg.MaxVersion = v
+	}
+
+	conn, err := r.dialTLS(target, cfg)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return fmt.Errorf("no peer certificates presented by %s", target)
+	}
+
+	data := make(map[string]interface{})
+	for k, v := range previous {
+		data[k] = v
+	}
+	for k, v := range dynamicValues {
+		data[k] = v
+	}
+	r.responseToDSLMap(data, target, conn, &state)
+
+	event := &protocols.InternalWrappedEvent{InternalEvent: data}
+	if r.CompiledOperators != nil {
+		result, ok := r.CompiledOperators.Execute(data, r.Match, r.Extract)
+		if ok && result != nil {
+			result.PayloadValues = dynamicValues
+			event.OperatorsResult = result
+			event.Results = r.MakeResultEvent(event)
+		}
+	}
+	callback(event)
+	return nil
+}
+
+func (r *Request) dialTLS(target string, cfg *tls.Config) (*tls.Conn, error) {
+	// Honour an injected dialer (e.g. proxy) by dialing TCP first, then doing
+	// the TLS handshake on top of it.
+	if r.options != nil && r.options.Options != nil && r.options.Options.DialContext != nil {
+		raw, err := r.options.Options.DialContext(context.Background(), "tcp", target)
+		if err != nil {
+			return nil, err
+		}
+		conn := tls.Client(raw, cfg)
+		_ = conn.SetDeadline(time.Now().Add(r.dialer.Timeout))
+		if err := conn.Handshake(); err != nil {
+			raw.Close()
+			return nil, err
+		}
+		return conn, nil
+	}
+	return tls.DialWithDialer(r.dialer, "tcp", target, cfg)
+}
+
+// responseToDSLMap flattens the leaf certificate and handshake state into
+// nuclei-compatible DSL keys.
+func (r *Request) responseToDSLMap(data map[string]interface{}, target string, conn *tls.Conn, state *tls.ConnectionState) {
+	leaf := state.PeerCertificates[0]
+	host, port := splitHostPort(target)
+	sni := state.ServerName
+	if sni == "" {
+		sni = host
+	}
+	certNames := certificateNames(leaf)
+	serial := formatSerial(leaf)
+	fingerprint := certificateFingerprintHash{
+		MD5:    certFingerprint(leaf, "md5"),
+		SHA1:   certFingerprint(leaf, "sha1"),
+		SHA256: certFingerprint(leaf, "sha256"),
+	}
+
+	// `revoked` is intentionally omitted: it needs OCSP/CRL fetching, which the
+	// stdlib-only handshake path does not do.
+	expired := time.Now().After(leaf.NotAfter)
+	mismatched := isMismatchedCert(sni, certNames)
+
+	flat := map[string]interface{}{
+		"host":         host,
+		"port":         port,
+		"matched":      target,
+		"probe_status": true,
+		// neutron always handshakes with crypto/tls, which tlsx labels "ctls";
+		// emit the engine name (string) to match nuclei rather than a bare bool.
+		"tls_connection":       "ctls",
+		"sni":                  sni,
+		"subject_cn":           leaf.Subject.CommonName,
+		"subject_an":           leaf.DNSNames,
+		"domains":              uniqueDomains(certNames),
+		"subject_dn":           leaf.Subject.String(),
+		"subject_org":          leaf.Subject.Organization,
+		"issuer_cn":            leaf.Issuer.CommonName,
+		"issuer_dn":            leaf.Issuer.String(),
+		"issuer_org":           leaf.Issuer.Organization,
+		"emails":               leaf.EmailAddresses,
+		"serial":               serial,
+		"not_before":           leaf.NotBefore,
+		"not_after":            leaf.NotAfter,
+		"tls_version":          tlsVersionName(state.Version),
+		"cipher":               cipherName(state.CipherSuite),
+		"fingerprint_hash":     fingerprint,
+		"wildcard_certificate": isWildcardName(certNames),
+		"self_signed":          isSelfSigned(leaf),
+		"expired":              expired,
+		"mismatched":           mismatched,
+	}
+	for k, v := range flat {
+		data[k] = v
+	}
+
+	if conn != nil {
+		if addr := conn.RemoteAddr(); addr != nil {
+			if ip, _, err := net.SplitHostPort(addr.String()); err == nil {
+				flat["ip"] = ip
+				data["ip"] = ip
+			}
+		}
+	}
+
+	// raw_cert: whole presented chain as concatenated DER, for xray-style
+	// bcontains(raw_cert, ...) matching.
+	var raw strings.Builder
+	for _, cert := range state.PeerCertificates {
+		raw.Write(cert.Raw)
+	}
+	data[common.RawCertKey] = raw.String()
+
+	// response: a JSON summary so `part: response` and DSL over the whole
+	// structure work, matching nuclei's default behaviour.
+	if encoded, err := json.Marshal(flat); err == nil {
+		data["response"] = string(encoded)
+	}
+	data["type"] = r.Type().String()
+}
+
+// MakeResultEvent creates a result event from an internal wrapped event.
+func (r *Request) MakeResultEvent(wrapped *protocols.InternalWrappedEvent) []*protocols.ResultEvent {
+	return protocols.MakeDefaultResultEvent(r, wrapped)
+}
+
+func (r *Request) GetCompiledOperators() []*operators.Operators {
+	return []*operators.Operators{r.CompiledOperators}
+}
+
+func (r *Request) MakeResultEventItem(wrapped *protocols.InternalWrappedEvent) *protocols.ResultEvent {
+	data := &protocols.ResultEvent{
+		TemplateID:       common.ToString(wrapped.InternalEvent["template-id"]),
+		Type:             common.ToString(wrapped.InternalEvent["type"]),
+		Host:             common.ToString(wrapped.InternalEvent["host"]),
+		Matched:          common.ToString(wrapped.InternalEvent["matched"]),
+		ExtractedResults: wrapped.OperatorsResult.OutputExtracts,
+		Metadata:         wrapped.OperatorsResult.PayloadValues,
+		Timestamp:        time.Now(),
+		IP:               common.ToString(wrapped.InternalEvent["ip"]),
+	}
+	return data
+}
+
+// --- helpers -------------------------------------------------------------
+
+func normalizeTarget(target string) string {
+	host, port := splitHostPort(target)
+	if host == "" {
+		return strings.TrimSpace(target)
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func splitHostPort(target string) (string, string) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", "443"
+	}
+	if strings.Contains(target, "://") || strings.HasPrefix(target, "//") {
+		if parsed, err := url.Parse(target); err == nil && parsed.Host != "" {
+			return splitAuthority(parsed.Host, defaultPortForScheme(parsed.Scheme))
+		}
+	}
+	if i := strings.IndexAny(target, "/?#"); i >= 0 {
+		target = target[:i]
+	}
+	return splitAuthority(target, "443")
+}
+
+func splitAuthority(authority, defaultPort string) (string, string) {
+	authority = strings.TrimSpace(authority)
+	if authority == "" {
+		return "", defaultPort
+	}
+	if host, port, err := net.SplitHostPort(authority); err == nil {
+		if port == "" {
+			port = defaultPort
+		}
+		return host, port
+	}
+	if strings.HasPrefix(authority, "[") {
+		if end := strings.Index(authority, "]"); end > 0 {
+			return authority[1:end], defaultPort
+		}
+	}
+	if strings.Count(authority, ":") == 1 {
+		parts := strings.SplitN(authority, ":", 2)
+		if parts[1] != "" {
+			return parts[0], parts[1]
+		}
+		return parts[0], defaultPort
+	}
+	return authority, defaultPort
+}
+
+func defaultPortForScheme(scheme string) string {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case "http":
+		return "80"
+	default:
+		return "443"
+	}
+}
+
+func formatSerial(cert *x509.Certificate) string {
+	if cert.SerialNumber == nil {
+		return ""
+	}
+	b := cert.SerialNumber.Bytes()
+	if len(b) == 0 {
+		return "00"
+	}
+	parts := make([]string, len(b))
+	for i, by := range b {
+		parts[i] = fmt.Sprintf("%02X", by)
+	}
+	return strings.Join(parts, ":")
+}
+
+func certFingerprint(cert *x509.Certificate, algo string) string {
+	switch algo {
+	case "md5":
+		sum := md5.Sum(cert.Raw)
+		return hex.EncodeToString(sum[:])
+	case "sha1":
+		sum := sha1.Sum(cert.Raw)
+		return hex.EncodeToString(sum[:])
+	default:
+		sum := sha256.Sum256(cert.Raw)
+		return hex.EncodeToString(sum[:])
+	}
+}
+
+type certificateFingerprintHash struct {
+	MD5    string `json:"md5,omitempty"`
+	SHA1   string `json:"sha1,omitempty"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+func certificateNames(cert *x509.Certificate) []string {
+	names := make([]string, 0, 1+len(cert.DNSNames))
+	if cert.Subject.CommonName != "" {
+		names = append(names, cert.Subject.CommonName)
+	}
+	names = append(names, cert.DNSNames...)
+	return names
+}
+
+func uniqueDomains(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	var domains []string
+	for _, name := range names {
+		domain := strings.TrimPrefix(name, "*.")
+		if domain == "" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func isWildcardName(names []string) bool {
+	for _, name := range names {
+		if strings.Contains(name, "*.") {
+			return true
+		}
+	}
+	return false
+}
+
+func isSelfSigned(cert *x509.Certificate) bool {
+	return len(cert.AuthorityKeyId) == 0 || bytes.Equal(cert.AuthorityKeyId, cert.SubjectKeyId)
+}
+
+func isMismatchedCert(host string, alternativeNames []string) bool {
+	hostTokens := strings.Split(host, ".")
+	for _, alternativeName := range alternativeNames {
+		if !strings.Contains(alternativeName, "*") {
+			if strings.EqualFold(alternativeName, host) {
+				return false
+			}
+			continue
+		}
+
+		nameTokens := strings.Split(alternativeName, ".")
+		if len(hostTokens) != len(nameTokens) {
+			continue
+		}
+		matched := false
+		for i, token := range nameTokens {
+			if i == 0 {
+				matched = matchWildcardToken(token, hostTokens[i])
+			} else {
+				matched = strings.EqualFold(token, hostTokens[i])
+			}
+			if !matched {
+				break
+			}
+		}
+		if matched {
+			return false
+		}
+	}
+	return true
+}
+
+func matchWildcardToken(name, host string) bool {
+	if !strings.Contains(name, "*") {
+		return strings.EqualFold(name, host)
+	}
+	parts := strings.Split(name, "*")
+	if strings.HasPrefix(name, "*") {
+		return len(parts) > 1 && strings.HasSuffix(host, parts[1])
+	}
+	if strings.HasSuffix(name, "*") {
+		return len(parts) > 0 && strings.HasPrefix(host, parts[0])
+	}
+	return len(parts) > 1 && strings.HasPrefix(host, parts[0]) && strings.HasSuffix(host, parts[1])
+}
+
+// tlsVersionValue maps a textual version to the crypto/tls constant. Literal
+// hex values keep this go1.11-safe (tls.VersionTLS13 was added in go1.12).
+func tlsVersionValue(name string) uint16 {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "sslv3", "ssl30":
+		return 0x0300
+	case "tls10", "tls1.0":
+		return 0x0301
+	case "tls11", "tls1.1":
+		return 0x0302
+	case "tls12", "tls1.2":
+		return 0x0303
+	case "tls13", "tls1.3":
+		return 0x0304
+	}
+	return 0
+}
+
+func tlsVersionName(version uint16) string {
+	switch version {
+	case 0x0300:
+		return "sslv3"
+	case 0x0301:
+		return "tls10"
+	case 0x0302:
+		return "tls11"
+	case 0x0303:
+		return "tls12"
+	case 0x0304:
+		return "tls13"
+	}
+	return fmt.Sprintf("0x%04x", version)
+}
+
+// cipherNames covers common suites by their crypto/tls constants (all present
+// in go1.11). Unknown suites fall back to a hex id.
+var cipherNames = map[uint16]string{
+	tls.TLS_RSA_WITH_AES_128_CBC_SHA:            "TLS_RSA_WITH_AES_128_CBC_SHA",
+	tls.TLS_RSA_WITH_AES_256_CBC_SHA:            "TLS_RSA_WITH_AES_256_CBC_SHA",
+	tls.TLS_RSA_WITH_AES_128_GCM_SHA256:         "TLS_RSA_WITH_AES_128_GCM_SHA256",
+	tls.TLS_RSA_WITH_AES_256_GCM_SHA384:         "TLS_RSA_WITH_AES_256_GCM_SHA384",
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305:    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:  "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+	0x1301: "TLS_AES_128_GCM_SHA256",
+	0x1302: "TLS_AES_256_GCM_SHA384",
+	0x1303: "TLS_CHACHA20_POLY1305_SHA256",
+	0x1304: "TLS_AES_128_CCM_SHA256",
+	0x1305: "TLS_AES_128_CCM_8_SHA256",
+}
+
+func cipherName(id uint16) string {
+	if name, ok := cipherNames[id]; ok {
+		return name
+	}
+	return fmt.Sprintf("0x%04x", id)
+}

--- a/protocols/ssl/ssl.go
+++ b/protocols/ssl/ssl.go
@@ -1,0 +1,67 @@
+// Package ssl implements a native, standard-library-only TLS/certificate
+// inspection protocol, modeled after nuclei's `ssl` protocol. It performs a
+// single TLS handshake (no HTTP request) against the target and exposes the
+// peer certificate as nuclei-compatible DSL keys (subject_cn, issuer_org,
+// serial, fingerprint_hash, tls_version, cipher, ...) for matchers/extractors.
+package ssl
+
+import (
+	"net"
+	"time"
+
+	"github.com/chainreactors/neutron/operators"
+	"github.com/chainreactors/neutron/protocols"
+)
+
+// Request contains an SSL protocol request to be made from a template.
+type Request struct {
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
+
+	// Address is the host:port target to connect to. Supports template variables
+	// such as {{Host}}:{{Port}}. When empty, the scan input is used.
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+
+	// MinVersion / MaxVersion bound the negotiated TLS version. Accepted values:
+	// sslv3, tls10, tls11, tls12, tls13. Empty means library default.
+	MinVersion string `json:"min_version,omitempty" yaml:"min_version,omitempty"`
+	MaxVersion string `json:"max_version,omitempty" yaml:"max_version,omitempty"`
+
+	operators.Operators `json:",inline,omitempty" yaml:",inline,omitempty"`
+
+	CompiledOperators *operators.Operators       `json:"-" yaml:"-" jsonschema:"-"`
+	dialer            *net.Dialer                `json:"-" yaml:"-" jsonschema:"-"`
+	options           *protocols.ExecuterOptions `json:"-" yaml:"-" jsonschema:"-"`
+}
+
+// Compile compiles the protocol request for further execution.
+func (r *Request) Compile(options *protocols.ExecuterOptions) error {
+	r.options = options
+
+	timeout := 5
+	if options != nil && options.Options != nil && options.Options.Timeout > 0 {
+		timeout = options.Options.Timeout
+	}
+	r.dialer = &net.Dialer{
+		Timeout:   time.Duration(timeout) * time.Second,
+		KeepAlive: 3 * time.Second,
+	}
+
+	if len(r.Matchers) > 0 || len(r.Extractors) > 0 {
+		compiled := &r.Operators
+		if err := compiled.Compile(); err != nil {
+			return err
+		}
+		r.CompiledOperators = compiled
+	}
+	return nil
+}
+
+// Requests returns the total number of requests the rule will perform.
+func (r *Request) Requests() int {
+	return 1
+}
+
+// GetID returns the unique ID of the request if any.
+func (r *Request) GetID() string {
+	return r.ID
+}

--- a/protocols/ssl/ssl_test.go
+++ b/protocols/ssl/ssl_test.go
@@ -1,0 +1,241 @@
+package ssl
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chainreactors/neutron/operators"
+	"github.com/chainreactors/neutron/protocols"
+	"gopkg.in/yaml.v3"
+)
+
+func newTestRequest(t *testing.T, matchers []*operators.Matcher) *Request {
+	t.Helper()
+	r := &Request{}
+	r.Operators = operators.Operators{Matchers: matchers}
+	opts := &protocols.ExecuterOptions{Options: &protocols.Options{Timeout: 5}}
+	if err := r.Compile(opts); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return r
+}
+
+func runAgainst(t *testing.T, r *Request, target string) *operators.Result {
+	t.Helper()
+	ctx := protocols.NewScanContext(target, nil)
+	var got *operators.Result
+	err := r.ExecuteWithResults(ctx, map[string]interface{}{}, map[string]interface{}{}, func(e *protocols.InternalWrappedEvent) {
+		if e.OperatorsResult != nil {
+			got = e.OperatorsResult
+		}
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return got
+}
+
+func TestSSLCertMatch(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+	// httptest's TLS server uses a cert with CN "127.0.0.1" / Org "Acme Co".
+	target := strings.TrimPrefix(server.URL, "https://")
+
+	r := newTestRequest(t, []*operators.Matcher{
+		{Type: "dsl", DSL: []string{`contains(subject_org, "Acme")`}},
+		{Type: "dsl", DSL: []string{`contains(tls_version, "tls")`}},
+	})
+	r.Operators.MatchersCondition = "and"
+	if err := r.CompiledOperators.Compile(); err != nil {
+		t.Fatalf("recompile: %v", err)
+	}
+
+	result := runAgainst(t, r, target)
+	if result == nil || !result.Matched {
+		t.Fatalf("expected cert match against %s, got %+v", target, result)
+	}
+}
+
+func TestSSLDefaultTargetAcceptsFullURLWithPath(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	r := newTestRequest(t, []*operators.Matcher{
+		{Type: "dsl", DSL: []string{`probe_status == true`}},
+	})
+	result := runAgainst(t, r, server.URL+"/nested/path")
+	if result == nil || !result.Matched {
+		t.Fatalf("expected SSL default target to normalize full URL, got %+v", result)
+	}
+}
+
+func TestSSLAddressYAML(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	var wrapper struct {
+		SSL []*Request `yaml:"ssl"`
+	}
+	raw := `
+ssl:
+  - address: "{{Host}}:{{Port}}"
+    matchers:
+      - type: dsl
+        dsl:
+          - probe_status == true
+`
+	if err := yaml.Unmarshal([]byte(raw), &wrapper); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(wrapper.SSL) != 1 || wrapper.SSL[0].Address != "{{Host}}:{{Port}}" {
+		t.Fatalf("expected scalar address to decode as canonical address: %+v", wrapper.SSL)
+	}
+	opts := &protocols.ExecuterOptions{Options: &protocols.Options{Timeout: 5}}
+	if err := wrapper.SSL[0].Compile(opts); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	result := runAgainst(t, wrapper.SSL[0], server.URL+"/from/input/path")
+	if result == nil || !result.Matched {
+		t.Fatalf("expected address template to match, got %+v", result)
+	}
+}
+
+func TestSSLRawCertAndFingerprint(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+	target := strings.TrimPrefix(server.URL, "https://")
+
+	// raw_cert should carry the org string from the DER, and response should
+	// expose the tlsx-compatible fingerprint_hash object.
+	r := newTestRequest(t, []*operators.Matcher{
+		{Type: "dsl", DSL: []string{`contains(raw_cert, "Acme")`}},
+		{Type: "regex", Part: "response", Regex: []string{`"sha256":"[0-9a-f]{64}"`}},
+	})
+	r.Operators.MatchersCondition = "and"
+	if err := r.CompiledOperators.Compile(); err != nil {
+		t.Fatalf("recompile: %v", err)
+	}
+
+	result := runAgainst(t, r, target)
+	if result == nil || !result.Matched {
+		t.Fatalf("expected raw_cert/fingerprint match against %s, got %+v", target, result)
+	}
+}
+
+func TestSSLResponseFieldsMatchNucleiShape(t *testing.T) {
+	notBefore := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	notAfter := time.Date(2120, 1, 2, 3, 4, 5, 0, time.UTC)
+	cert := &x509.Certificate{
+		Raw:            []byte("certificate-bytes"),
+		DNSNames:       []string{"one.example", "two.example"},
+		EmailAddresses: []string{"admin@example.com"},
+		NotBefore:      notBefore,
+		NotAfter:       notAfter,
+		SerialNumber:   big.NewInt(0x1234),
+		Subject: pkix.Name{
+			CommonName:   "leaf",
+			Organization: []string{"Org"},
+		},
+		Issuer: pkix.Name{CommonName: "issuer"},
+	}
+	state := &tls.ConnectionState{
+		Version:          0x0304,
+		CipherSuite:      0x1301,
+		ServerName:       "one.example",
+		PeerCertificates: []*x509.Certificate{cert},
+	}
+	data := map[string]interface{}{}
+
+	(&Request{}).responseToDSLMap(data, "one.example:443", nil, state)
+
+	if data["probe_status"] != true || data["tls_connection"] != "ctls" {
+		t.Fatalf("missing nuclei status fields: %+v", data)
+	}
+	fp, ok := data["fingerprint_hash"].(certificateFingerprintHash)
+	if !ok || len(fp.SHA256) != 64 || len(fp.SHA1) != 40 || len(fp.MD5) != 32 {
+		t.Fatalf("fingerprint_hash should be the tlsx object shape: %#v", data["fingerprint_hash"])
+	}
+	if _, ok := data["fingerprint_hash.sha256"]; ok {
+		t.Fatalf("unexpected dotted fingerprint fallback key: %+v", data)
+	}
+	if _, ok := data["fingerprint_sha256"]; ok {
+		t.Fatalf("unexpected flat fingerprint fallback key: %+v", data)
+	}
+	if _, ok := data["expired"].(bool); !ok {
+		t.Fatalf("expired flag should be a bool: %+v", data)
+	}
+	if data["expired"] != false || data["mismatched"] != false {
+		t.Fatalf("unexpected certificate state flags: %+v", data)
+	}
+	if got := data["domains"].([]string); !sameStrings(got, []string{"leaf", "one.example", "two.example"}) {
+		t.Fatalf("unexpected nuclei domains shape: %#v", got)
+	}
+	if data["sni"] != "one.example" || data["subject_cn"] != "leaf" {
+		t.Fatalf("missing domain/sni fields: %+v", data)
+	}
+	if data["serial"] != "12:34" {
+		t.Fatalf("unexpected serial format: %v", data["serial"])
+	}
+	if data["cipher"] != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected TLS 1.3 cipher name: %v", data["cipher"])
+	}
+	if got, ok := data["not_before"].(time.Time); !ok || !got.Equal(notBefore) {
+		t.Fatalf("not_before should stay a time.Time: %#v", data["not_before"])
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal([]byte(data["response"].(string)), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	responseFP, ok := response["fingerprint_hash"].(map[string]interface{})
+	if !ok || responseFP["sha256"] != fp.SHA256 {
+		t.Fatalf("response JSON missing fingerprint_hash object: %#v", response["fingerprint_hash"])
+	}
+	if response["not_before"] != notBefore.Format(time.RFC3339) {
+		t.Fatalf("response JSON should marshal time as RFC3339: %#v", response["not_before"])
+	}
+}
+
+func TestSSLExpiredDoesNotMatchNotYetValid(t *testing.T) {
+	now := time.Now()
+	cert := &x509.Certificate{
+		Raw:          []byte("certificate-bytes"),
+		DNSNames:     []string{"one.example"},
+		NotBefore:    now.Add(24 * time.Hour),
+		NotAfter:     now.Add(48 * time.Hour),
+		SerialNumber: big.NewInt(1),
+	}
+	state := &tls.ConnectionState{
+		Version:          0x0304,
+		CipherSuite:      0x1301,
+		ServerName:       "one.example",
+		PeerCertificates: []*x509.Certificate{cert},
+	}
+	data := map[string]interface{}{}
+
+	(&Request{}).responseToDSLMap(data, "one.example:443", nil, state)
+
+	if data["expired"] != false {
+		t.Fatalf("not-yet-valid certificate should not be marked expired: %+v", data)
+	}
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/protocols/types.go
+++ b/protocols/types.go
@@ -18,6 +18,8 @@ const (
 	FileProtocol
 	// name:http
 	HTTPProtocol
+	// name:ssl
+	SSLProtocol
 	InvalidProtocol
 )
 
@@ -27,6 +29,7 @@ var protocolMappings = map[ProtocolType]string{
 	FileProtocol:    "file",
 	HTTPProtocol:    "http",
 	NetworkProtocol: "network",
+	SSLProtocol:     "ssl",
 }
 
 func (t ProtocolType) String() string {

--- a/templates/impl.go
+++ b/templates/impl.go
@@ -93,6 +93,10 @@ func (t *Template) Execute(input string, payload map[string]interface{}) (*opera
 // execution only. The client is threaded through the ScanContext down to request
 // execution, so the shared compiled template is never mutated at runtime — making
 // concurrent active-match calls safe. A nil client falls back to Execute's behavior.
+//
+// Deprecated: prefer ExecuteWithTransport. Passing a wholesale http.Client
+// discards the template's compiled CheckRedirect/Jar/Timeout — templates with
+// `redirects: false` then silently follow 302s and lose Location-header matches.
 func (t *Template) ExecuteWithClient(input string, payload map[string]interface{}, client *http.Client) (*operators.Result, error) {
 	if t.Executor.Options().Options.Opsec && t.Opsec {
 		common.Debug("(opsec!!!) skip template %s", t.Id)
@@ -100,6 +104,21 @@ func (t *Template) ExecuteWithClient(input string, payload map[string]interface{
 	}
 	ctx := protocols.NewScanContext(input, payload)
 	ctx.Client = client
+	return t.Executor.Execute(ctx)
+}
+
+// ExecuteWithTransport runs the template using the provided RoundTripper for
+// this execution only. Unlike ExecuteWithClient, the template's compiled
+// CheckRedirect, cookie jar, and timeout are preserved — only the transport
+// layer is swapped. Active-match engines that need to plug in a caching or
+// instrumented transport should prefer this.
+func (t *Template) ExecuteWithTransport(input string, payload map[string]interface{}, transport http.RoundTripper) (*operators.Result, error) {
+	if t.Executor.Options().Options.Opsec && t.Opsec {
+		common.Debug("(opsec!!!) skip template %s", t.Id)
+		return nil, protocols.OpsecError
+	}
+	ctx := protocols.NewScanContext(input, payload)
+	ctx.Transport = transport
 	return t.Executor.Execute(ctx)
 }
 


### PR DESCRIPTION
## 背景

2026-06-08 SDK v0.2.4 在 1655 个真实抓取目标上跑 `batch_compare`(r5 全量实跑),发现 22 件指纹在转换→执行链路上漏检明显。本 PR 把对应的运行期/转换期收口改动 + 一份可复跑的回归基线一并提交。

四条 commit 各自独立可编译,逐条 push:

1. **`neutron(common+http)` cert 字段注册表** — `common.XrayCertFields` 作单源映射,HTTP 运行期 cert 字段从 4 个扩到 8 个 + `raw_cert`(整条链 DER),`TestCertFieldRegistryParity` 守住注册表与 extractor 不漂移。
2. **`neutron(ssl)` 纯 TLS 探测协议** — 标准库实现,仿 nuclei `ssl` 协议,单次握手暴露 leaf cert 为 DSL 键,注册 `SSLProtocol`。
3. **`neutron(http)` Transport-only 注入** — `ScanContext.Transport` 替代整包替换 `Client`,浅克隆保住模板 `CheckRedirect`/`Jar`/`Timeout`;修掉 `redirects: false` 模板被静默改成跟 302 的漏检根因。`ExecuteWithTransport` 入口,旧 `Client`/`ExecuteWithClient` 标 Deprecated。
4. **`neutron(ci)` bad-case 回归基线 + convert/ssl 进 CI** — 21 件 xray 指纹 YAML(原始格式,测试现场 `Convert→Compile→Execute`) + 219 行实测 URL(带 r5 时刻 sdk_match);`./protocols/ssl/` 与 `./convert/` 此前完全不在 CI,本次纳入(`-short`)。

## 一个发现

21 件 bad-case YAML 在当前 `master` 上 `Convert + Compile` **全部 PASS**——说明 r5 的 0/10 漏检**不在转换链**,根因在运行期(主动探测 / `redirects:false` / 末块超时)。commit 1–3 正对症。这是 CI 第一份命中率 baseline。

## 验证

```
go test ./operators/ ./protocols/ ./protocols/http/ ./protocols/ssl/ ./templates/ ./convert/ -short -count=1 -timeout=180s
```

本地 default + `-tags json` 两套 build 均通过。实测命中率复跑:`go test ./convert/ -run BadCaseFinger -timeout 30m`(默认 `-short` 跳过联网)。
